### PR TITLE
create persistent eta bins in standard_test, pass refs to runBuilding…

### DIFF
--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -597,10 +597,10 @@ void MkBuilder::FindTracks(EventOfCombCandidates& event_of_comb_cands)
 
 
 //==============================================================================
-// runBuildTestPlexBestHit
+// runBuildingTestPlexBestHit
 //==============================================================================
 
-double runBuildingTestPlexBestHit(Event& ev)
+double runBuildingTestPlexBestHit(Event& ev, EventOfCandidates& event_of_cands)
 {
   MkBuilder builder;
 
@@ -614,7 +614,8 @@ double runBuildingTestPlexBestHit(Event& ev)
 
   builder.fit_seeds();
 
-  EventOfCandidates event_of_cands;
+  //EventOfCandidates event_of_cands;
+  event_of_cands.Reset();
 
   builder.FindTracksBestHit(event_of_cands);
 
@@ -645,10 +646,10 @@ double runBuildingTestPlexBestHit(Event& ev)
 
 
 //==============================================================================
-// runBuildTestPlex
+// runBuildingTestPlex
 //==============================================================================
 
-double runBuildingTestPlex(Event& ev)
+double runBuildingTestPlex(Event& ev, EventOfCombCandidates& event_of_comb_cands)
 {
   MkBuilder builder;
 
@@ -662,7 +663,8 @@ double runBuildingTestPlex(Event& ev)
 
   builder.fit_seeds();
 
-  EventOfCombCandidates event_of_comb_cands;
+  //EventOfCombCandidates event_of_comb_cands;
+  event_of_comb_cands.Reset();
 
   builder.FindTracks(event_of_comb_cands);
 

--- a/mkFit/buildtestMPlex.h
+++ b/mkFit/buildtestMPlex.h
@@ -3,8 +3,9 @@
 
 #include "Event.h"
 #include "Track.h"
+#include "MkFitter.h"
 
-double runBuildingTestPlex(Event& ev);
-double runBuildingTestPlexBestHit(Event& ev);
+double runBuildingTestPlex(Event& ev, EventOfCombCandidates& event_of_comb_cands);
+double runBuildingTestPlexBestHit(Event& ev, EventOfCandidates& event_of_cands);
 
 #endif

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -156,6 +156,12 @@ void test_standard()
   initGeom(geom);
   Validation val;
 
+  EventOfCombCandidates evocc;
+  EventOfCombCandidates& event_of_comb_cands = evocc;
+
+  EventOfCandidates evoc;
+  EventOfCandidates& event_of_cands = evoc;
+
   double s_tmp=0, s_tsm=0, s_tsm2=0, s_tmp2=0, s_tsm2bh=0, s_tmp2bh=0;
 
   printf("\n");
@@ -178,9 +184,9 @@ void test_standard()
     plex_tracks.resize(ev.simTracks_.size());
     double tmp = runFittingTestPlex(ev, plex_tracks);
 
-    double tmp2 = runBuildingTestPlex(ev);
+    double tmp2 = runBuildingTestPlex(ev, event_of_comb_cands);
 
-    double tmp2bh = runBuildingTestPlexBestHit(ev);
+    double tmp2bh = runBuildingTestPlexBestHit(ev, event_of_cands);
 
     printf("Matriplex fit = %.5f  --- Build  MX = %.5f  BHMX = %.5f\n",
            tmp, tmp2, tmp2bh);


### PR DESCRIPTION
…TestPlex(BestHit), call Reset() there

The intention of this merge is to improve parallel performance, as confirmed in tests using the mt-2 branch. However, my observation is that performance is actually WORSE if the current changes are incorporated into in the devel branch. The reason is unclear. Perhaps it only matters for code that uses the reduced data structures, which have not yet been merged into the devel branch from mt-2? I'm making this pull request anyway - even though I'm not sure if it should be accepted yet -