### PR TITLE
More Validation Tools, Cleanups of seedtest with Configs, discard normalizeEta, change getPhiPartition

### DIFF
--- a/BinInfoUtils.h
+++ b/BinInfoUtils.h
@@ -32,13 +32,16 @@ inline unsigned int getPhiPartition(float phi){
   //assume phi is between -PI and PI
   //  if (!(fabs(phi)<Config::PI)) std::cout << "anomalous phi=" << phi << std::endl;
   //  const float phiPlusPi  = std::fmod(phi+Config::PI,Config::TwoPI); // normaliztion done here
-  const float phiPlusPi  = phi+Config::PI; 
-  const unsigned int bin = phiPlusPi*Config::fPhiFactor; // would have to change this to just a regular int (no const) if want to use commented lines below
-  //  second condition appeared once in very bizarre corner case where propagated phi == pi != Config::PI in check of normalizedPhi 
-  //  i.e. delta on floating point check smaller than comparison... making what should be bin = nPhiPart - 1 instead bin = nPhiPart (out of bounds!!) 
-  //  if      (bin<0)                 bin = 0;
-  //  else if (bin>=Config::nPhiPart) bin = Config::nPhiPart - 1;
-  return bin;
+  const float phiPlusPi = phi+Config::PI; 
+  int bin = phiPlusPi*Config::fPhiFactor;
+  
+  // theoretically these checks below should be taken care of by normalizedPhi, however...
+  // these condition checks appeared in very bizarre corner case where propagated phi == pi != Config::PI in check of normalizedPhi (but not unexpected... comparing float point numbers)
+  // i.e. delta on floating point check smaller than comparison... making what should be bin = nPhiPart - 1 instead bin = nPhiPart (out of bounds!!) ...or worse if unsigned bin < 0, bin == unsigned int max!
+  if (bin<0)                      bin = 0;
+  else if (bin>=Config::nPhiPart) bin = Config::nPhiPart - 1;
+
+  return (unsigned int) bin;
 }
 
 inline unsigned int getEtaPartition(float eta){

--- a/BinInfoUtils.h
+++ b/BinInfoUtils.h
@@ -33,7 +33,7 @@ inline unsigned int getPhiPartition(float phi){
   //  if (!(fabs(phi)<Config::PI)) std::cout << "anomalous phi=" << phi << std::endl;
   //  const float phiPlusPi  = std::fmod(phi+Config::PI,Config::TwoPI); // normaliztion done here
   const float phiPlusPi  = phi+Config::PI; 
-  const unsigned int bin = phiPlusPi*Config::fPhiFactor;
+  const unsigned int bin = phiPlusPi*Config::fPhiFactor; // would have to change this to just a regular int (no const) if want to use commented lines below
   //  second condition appeared once in very bizarre corner case where propagated phi == pi != Config::PI in check of normalizedPhi 
   //  i.e. delta on floating point check smaller than comparison... making what should be bin = nPhiPart - 1 instead bin = nPhiPart (out of bounds!!) 
   //  if      (bin<0)                 bin = 0;
@@ -43,11 +43,12 @@ inline unsigned int getPhiPartition(float phi){
 
 inline unsigned int getEtaPartition(float eta){
   const float etaPlusEtaDet  = eta + Config::fEtaDet;
-  const unsigned int bin     = (etaPlusEtaDet * Config::nEtaPart) / (Config::fEtaFull);  // ten bins for now ... update if changed in Event.cc
+  int bin = (etaPlusEtaDet * Config::nEtaPart) / (Config::fEtaFull);  // ten bins for now ... update if changed in Event.cc
   // use this check instead of normalizedEta()... directly bin into first/last bins eta of range of detector
-  if      (etabin<0)                 etabin = 0; 
-  else if (etabin>=Config::nEtaPart) etabin = Config::nEtaPart - 1;
-  return bin;
+  if      (bin<0)                 bin = 0; 
+  else if (bin>=Config::nEtaPart) bin = Config::nEtaPart - 1;
+
+  return (unsigned int) bin;
 }
 
 std::vector<unsigned int> getCandHitIndices(const unsigned int &, const unsigned int &, const unsigned int &, const unsigned int &, const BinInfoLayerMap &);

--- a/BinInfoUtils.h
+++ b/BinInfoUtils.h
@@ -34,21 +34,21 @@ inline unsigned int getPhiPartition(float phi){
   //  const float phiPlusPi  = std::fmod(phi+Config::PI,Config::TwoPI); // normaliztion done here
   const float phiPlusPi  = phi+Config::PI; 
   const unsigned int bin = phiPlusPi*Config::fPhiFactor;
+  //  second condition appeared once in very bizarre corner case where propagated phi == pi != Config::PI in check of normalizedPhi 
+  //  i.e. delta on floating point check smaller than comparison... making what should be bin = nPhiPart - 1 instead bin = nPhiPart (out of bounds!!) 
+  //  if      (bin<0)                 bin = 0;
+  //  else if (bin>=Config::nPhiPart) bin = Config::nPhiPart - 1;
   return bin;
 }
 
 inline unsigned int getEtaPartition(float eta){
   const float etaPlusEtaDet  = eta + Config::fEtaDet;
   const unsigned int bin     = (etaPlusEtaDet * Config::nEtaPart) / (Config::fEtaFull);  // ten bins for now ... update if changed in Event.cc
+  // use this check instead of normalizedEta()... directly bin into first/last bins eta of range of detector
+  if      (etabin<0)                 etabin = 0; 
+  else if (etabin>=Config::nEtaPart) etabin = Config::nEtaPart - 1;
   return bin;
 }
-			      
-#ifdef ETASEG
-inline float normalizedEta(float eta) {
-  if (std::abs(eta)>=Config::fEtaDet) {eta = (eta>0 ? Config::fEtaDet*0.99 : -Config::fEtaDet*0.99);}
-  return eta;
-}
-#endif
 
 std::vector<unsigned int> getCandHitIndices(const unsigned int &, const unsigned int &, const unsigned int &, const unsigned int &, const BinInfoLayerMap &);
 

--- a/BinInfoUtils.h
+++ b/BinInfoUtils.h
@@ -45,7 +45,7 @@ inline unsigned int getEtaPartition(float eta){
 			      
 #ifdef ETASEG
 inline float normalizedEta(float eta) {
-  if (std::abs(eta)>Config::fEtaDet) {eta = (eta>0 ? Config::fEtaDet*0.99 : -Config::fEtaDet*0.99);}
+  if (std::abs(eta)>=Config::fEtaDet) {eta = (eta>0 ? Config::fEtaDet*0.99 : -Config::fEtaDet*0.99);}
   return eta;
 }
 #endif

--- a/Config.h
+++ b/Config.h
@@ -62,8 +62,10 @@ namespace Config{
 
   // Config for seeding
   constexpr unsigned int nlayers_per_seed = 3;
-
-  constexpr float chi2seedcut = 9.0;
+  constexpr float chi2seedcut  = 9.0;
+  constexpr float alphaBeta    = 0.0520195; // 0.0458378 --> for d0 = .0025 cm --> analytically derived... depends on geometry of detector --> from mathematica
+  constexpr float dEtaSeedTrip = 0.6; // for almost max efficiency --> empirically derived... depends on geometry of detector
+  constexpr float dPhiSeedTrip = 0.0458712; // numerically+semianalytically derived... depends on geometry of detector
 
   // Config for Hit and BinInfoUtils
   constexpr unsigned int nPhiPart   = 80; //315 = 63*5  //63; //80; 

--- a/Event.cc
+++ b/Event.cc
@@ -99,7 +99,7 @@ void Event::Segment()
     std::sort(layerHits_[ilayer].begin(), layerHits_[ilayer].end(), sortByZ);
     std::vector<unsigned int> lay_eta_bin_count(Config::nEtaPart);
     for (unsigned int ihit=0;ihit<layerHits_[ilayer].size();++ihit) {
-      unsigned int etabin = getEtaPartition(normalizedEta(layerHits_[ilayer][ihit].eta()));
+      unsigned int etabin = getEtaPartition(layerHits_[ilayer][ihit].eta());
       dprint("ihit: " << ihit << " eta: " << layerHits_[ilayer][ihit].eta() << " etabin: " << etabin);
       lay_eta_bin_count[etabin]++;
     }

--- a/PlotValidation.cpp
+++ b/PlotValidation.cpp
@@ -489,7 +489,7 @@ void PlotValidation::PlotTiming(){
   subdir->cd();
   
   // output plots
-  Bool_t zeroSupLin;
+  Bool_t zeroSupLin = true;
 
   // make new timing plots
   TH1F * tottime = new TH1F("h_total_timing","Total Time Spent in Simulation",6,0,6);
@@ -653,11 +653,6 @@ void PlotValidation::PlotSegment(){
       // fill eta-phi bin plots
       for (UInt_t iphi = 0; iphi < nPhiPart; iphi++){
 	phibinplots[ilay][ieta]->SetBinContent(iphi+1,nHitsPhiVVV[ilay][ieta][iphi]);
-	
-	if (ilay == 9) {
-	  total += nHitsPhiVVV[ilay][ieta][iphi];
-	}
-	
 	nHitsplots[ilay]->Fill(nHitsPhiVVV[ilay][ieta][iphi]);
       }
     }

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -485,14 +485,11 @@ void TTreeValidation::fillBranchTree(const unsigned int evtID)
   evtID_br_  = evtID;
   for (TkToBVVMMIter seediter = seedToBranchValVecLayMapMap_.begin(); seediter != seedToBranchValVecLayMapMap_.end(); ++seediter){
     seedID_br_ = (*seediter).first;
-    /*
-    std::cout << std::endl;
-    std::cout << "Seed ID: " << seedID_br_ << std::endl;
-    */
     for (BVVLMiter layiter = (*seediter).second.begin(); layiter != (*seediter).second.end(); ++layiter){
       const auto& BranchValVec((*layiter).second);
       const unsigned int cands = BranchValVec.size();
- 
+      layer_  = (*layiter).first; // first index here is layer
+
       // clear vectors before filling
       candEtaPhiBins_.clear();
       candHits_.clear();
@@ -516,12 +513,6 @@ void TTreeValidation::fillBranchTree(const unsigned int evtID)
 
       for (unsigned int cand = 0; cand < cands; cand++){ // loop over input candidates at this layer for this seed
 	const auto& BranchVal(BranchValVec[cand]); // grab the branch validation object
-	
-	/*	if ((*layiter).first == 9){
-	  std::cout << "Cand: " << cand << std::endl;
-	  std::cout << "pM: " << BranchVal.phiBinMinus << " pP: " << BranchVal.phiBinPlus << std::endl;
-	  std::cout << "eM: " << BranchVal.etaBinMinus << " eP: " << BranchVal.etaBinPlus << std::endl;
-	  }*/
 
 	////////////////////////////////////
 	//  EtaPhiBins Explored Counting  //
@@ -547,16 +538,13 @@ void TTreeValidation::fillBranchTree(const unsigned int evtID)
 	    uniqueEtaPhiBins[ibin] = true;
 	  }
 	}
-
+	
 	//////////////////////////////
 	//  Hits Explored Counting  //
 	//////////////////////////////
 
 	candHits[cand] = BranchVal.cand_hit_indices.size(); // set value of nHits explored per input cand for this seed+layer
 	for (auto&& cand_hit_idx : BranchVal.cand_hit_indices){ // save unique hits 
-	  /*  if ((*layiter).first == 9){
-	    std::cout << "layer9 hit: " << cand_hit_idx << std::endl;
-	    }*/
 	  uniqueHits[cand_hit_idx] = true;
 	}
 
@@ -577,7 +565,6 @@ void TTreeValidation::fillBranchTree(const unsigned int evtID)
     
       // fill the rest of the tree after identifying uniques
 
-      layer_  = (*layiter).first; // first index here is layer
       cands_  = cands;
       
       // will use these to create total plots (once summed by looping over the vectors), and make per input candidate by looping over these vectors individually

--- a/buildtest.cc
+++ b/buildtest.cc
@@ -198,8 +198,8 @@ void extendCandidate(const Event& ev, const cand_t& cand, candvec& tmp_candidate
   const float eta  = getEta(std::sqrt(getRad2(predx,predy)),predz);
   const float deta = std::sqrt(std::abs(getEtaErr2(predx,predy,predz,propState.errors.At(0,0),propState.errors.At(1,1),propState.errors.At(2,2),propState.errors.At(0,1),propState.errors.At(0,2),propState.errors.At(1,2))));
   const float nSigmaDeta = std::min(std::max(Config::nSigma*deta,(float) Config::minDEta), (float) Config::maxDEta); // something to tune -- minDEta = 0.0
-  const auto etaBinMinus = getEtaPartition(normalizedEta(eta-nSigmaDeta));
-  const auto etaBinPlus  = getEtaPartition(normalizedEta(eta+nSigmaDeta));
+  const auto etaBinMinus = getEtaPartition(eta-nSigmaDeta);
+  const auto etaBinPlus  = getEtaPartition(eta+nSigmaDeta);
 #else
   const float nSigmaDeta = 0.;
   const auto etaBinMinus = 0U;

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -87,8 +87,8 @@ void buildHitPairs(const std::vector<HitVec>& evt_lay_hits, const BinInfoLayerMa
     const float outerphi  = evt_lay_hits[1][ihit].phi();
 
 #ifdef ETASEG
-    const auto etaBinMinus = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz-Config::dZ)/2.));
-    const auto etaBinPlus  = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz+Config::dZ)/2.));
+    const auto etaBinMinus = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz-Config::beamspotZ)/2.));
+    const auto etaBinPlus  = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz+Config::beamspotZ)/2.));
 #else
     const auto etaBinMinus = 0U;
     const auto etaBinPlus  = 0U;
@@ -169,7 +169,7 @@ void filterHitTripletsByRZChi2(const std::vector<HitVec>& hit_triplets, std::vec
  
     float chi2fit = 0;     
     for (auto&& seedhit : hit_triplet) { //now perform chi2 on fit!
-      chi2fit += pow((seedhit.z() - aParam - (bParam * seedhit.r())),2) / varZ;
+      chi2fit += pow((seedhit.z() - aParam - (bParam * seedhit.r())),2) / Config::varZ;
     }
 
     if (chi2fit<Config::chi2seedcut){ // cut empirically derived


### PR DESCRIPTION
Hi All,

I have a number of changes I would like committed that do not affect physics performance (although may affect timing performance of MkFit if my BinInfoUtils.cc will be used in mkFit). 

1) I have included more validation plots (hurray!). 

2) I cleaned up seedtest.cc as Giuseppe said he might start playing around with it.  Mainly, this just meant replacing hardcoded consts with consts in Config.h

3) I did away with normalizedEta() in BinInfoUtils (and where it is called in the SMatrix code).  The reason is something sinister... floating point comparisons that fail (when 1 != 1).  I kept getting really annoying crashes when this happened.  Instead, I have chosen to just bin directly any output of the bin calculation that is outside the bounds of our virtual detector eta bins.  

4) Need the same bin check in getPhiPartition as well... had a nasty corner case of pi != pi that caused code to crash as it returned a bin number = Config::nPhiPart (which is +1 outside the range of 0 - Config::nPhiPart).  Would be nice if we could use module on phi wrapping, but I have checked this before, and anything more than a few radians away from phi < |pi| it gets progressively worse with increase in distance from pi.

N.B. This PR incorporates all the PRs from before (i.e. can be automatically merged).
