### PR TITLE
Change HitID types from short to int

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -9,9 +9,9 @@
 
 struct HitID {
   HitID() : layer(-1), index(-1) {}
-  HitID(short l, short i) : layer(l), index(i) {}
-  short layer;
-  short index;
+  HitID(int l, int i) : layer(l), index(i) {}
+  int layer;
+  int index;
 };
 typedef std::vector<HitID> HitIDVec;
 


### PR DESCRIPTION
Source of 30k event limit.  I had thought this would be used more than it is, so I over-optimized.  Only used in MC generation, so doesn't matter so much.