### PR TITLE
Fix an issue when running clone-engine with more than 21 threads.

### DIFF
--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -27,6 +27,8 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
 
   const int is_num = is_end - is_beg;
 
+  // printf("CandCloner::ProcessSeedRange is_beg=%d, is_end=%d, is_num=%d\n", is_beg, is_end, is_num);
+
   //1) sort the candidates
   for (int is = is_beg; is < is_end; ++is)
   {
@@ -60,7 +62,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
     std::vector<MkFitter::IdxChi2List>& hitsToAddForThisSeed = m_hits_to_add[is];
     for (int ih = 0; ih < hitsToAddForThisSeed.size() && ih < Config::maxCandsPerSeed; ih++)
     {
-      t_seed_newcand_idx.push_back(std::pair<int,MkFitter::IdxChi2List>(is, hitsToAddForThisSeed[ih]));
+      t_seed_newcand_idx.push_back(std::pair<int,MkFitter::IdxChi2List>(is + m_start_seed, hitsToAddForThisSeed[ih]));
     }
   }
 

--- a/mkFit/CandCloner.h
+++ b/mkFit/CandCloner.h
@@ -150,7 +150,7 @@ public:
 
   void signal_work_to_st(int idx)
   {
-    // printf("CandCloner::signal_work_to_st assigning work up to seed %d\n", idx);
+    // printf("CandCloner::signal_work_to_st assigning work from seed %d to %d\n", m_idx_max_prev, idx);
 
     if ( ! Config::clonerUseSingleThread)
       QueueWork(std::make_pair(m_idx_max_prev, idx));

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -452,9 +452,12 @@ struct OmpThreadData
     th_n_seeds = th_end_seed - th_start_seed;
 
 #ifdef DEBUG
-      omp_set_lock(&writelock);
-      std::cout << "th_start_seed=" << th_start_seed << " th_end_seed=" << th_end_seed << std::endl;
-      omp_unset_lock(&writelock);
+    omp_set_lock(&writelock);
+    printf("thread_num=%d, num_threads=%d\n", thread_num, num_threads);
+    printf("n_th_per_eta_bin=%d, n_eta_bin_per_th=%d\n", n_th_per_eta_bin, n_eta_bin_per_th);
+    printf("th_start_ebin=%d, th_end_ebin=%d\n", th_start_ebin, th_end_ebin);
+    printf("th_start_seed=%d, th_end_seed=%d, th_n_seeds=%d\n", th_start_seed, th_end_seed, th_n_seeds);
+    omp_unset_lock(&writelock);
 #endif
   }
 };

--- a/mkFit/SideThread.h
+++ b/mkFit/SideThread.h
@@ -148,7 +148,7 @@ public:
 
   void JoinSideThread()
   {
-    printf("SideThread::JoinSideThread entering ...\n");
+    // printf("SideThread::JoinSideThread entering ...\n");
     // printf("SideThread::JoinSideThread in cpuid %d\n", sched_getcpu());
     {
       std::unique_lock<std::mutex> lk(m_moo);


### PR DESCRIPTION
Works also on mic, got best results with:
./mkFit-mic --build-ce --num-thr 168 --cloner-single-thread