### PR TITLE
Revive auotmatic dependency generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ifeq (${CXX},icc)
   EXES   += $(addsuffix -mic, ${TGTS})
 endif
 
+.PHONY: all clean distclean
+
 all: ${EXES}
 	cd mkFit && ${MAKE}
 
@@ -23,19 +25,20 @@ AUTO_TGTS += auto-matriplex
 endif
 
 SRCS := $(wildcard *.cc)
-DEPS := $(SRCS:.cc=.d)
 OBJS := $(SRCS:.cc=.o)
 
--include ${DEPS}
+ifeq ($(filter clean-local clean distclean, ${MAKECMDGOALS}),)
+include $(SRCS:.cc=.d)
+endif
 
-.PHONY: all clean 
-
-clean:
+clean-local:
 	-rm -f ${EXES} *.d *.o *.om
 	-rm -rf USolids-{host,mic}
+
+clean: clean-local
 	cd mkFit && ${MAKE} clean
 
-distclean: clean
+distclean: clean-local
 	-rm -f ${AUTO_TGTS}
 	-rm -f *.optrpt
 	cd mkFit && ${MAKE} distclean
@@ -43,7 +46,7 @@ distclean: clean
 main: ${AUTO_TGTS} ${OBJS} ${LIBUSOLIDS}
 	${CXX} ${CXXFLAGS} ${VEC_HOST} -o $@ ${OBJS} ${LIBUSOLIDS} ${LDFLAGS}
 
-${OBJS}: %.o: %.cc
+${OBJS}: %.o: %.cc %.d
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${VEC_HOST} -c -o $@ $<
 
 ${LIBUSOLIDS} : USolids/CMakeLists.txt

--- a/Makefile.config
+++ b/Makefile.config
@@ -94,8 +94,8 @@ GEN_FLAT_ETA := -DGENFLATETA
 # Derived settings
 ################################################################
 
-CPPFLAGS := -I. ${USE_MATRIPLEX} ${USE_INTRINSICS} # -MMD
-CXXFLAGS := ${OPT} -std=c++11 ${OSX_CXXFLAGS}
+CPPFLAGS := -I. ${USE_MATRIPLEX} ${USE_INTRINSICS} -std=c++11
+CXXFLAGS := ${OPT} ${OSX_CXXFLAGS}
 LDFLAGS  := ${OSX_LDFLAGS}
 
 LDFLAGS_HOST :=
@@ -160,3 +160,13 @@ ifdef WITH_ROOT
 else
   CPPFLAGS += -DNO_ROOT
 endif
+
+################################################################
+# Dependency generation
+################################################################
+
+# Always use gcc as icc used to have trouble with this (? check if still true)
+MAKEDEPEND = gcc -MM -MG ${CPPFLAGS}
+
+%.d: %.cc
+	${MAKEDEPEND} -o $@ $<

--- a/mkFit/Makefile
+++ b/mkFit/Makefile
@@ -18,6 +18,9 @@ LDFLAGS  += ${LDEXTRA}
 CPPFLAGS_NO_ROOT += ${CPPEXTRA}
 LDFLAGS_NO_ROOT  += ${LDEXTRA}
 
+.PHONY: all clean distclean echo
+
+all: default
 
 TGTS     := mkFit
 
@@ -27,25 +30,32 @@ ifeq (${CXX},icc)
   EXES   += $(addsuffix -mic, ${TGTS})
 endif
 
-
-all:: ${AUTO_TGTS}
-all:: ${EXES}
-
 auto-matriplex:
 	${MAKE} -C ../Matriplex auto && touch $@
 
+AUTO_HEADERS := upParam_MultKalmanGain.ah \
+		upParam_simil_x_propErr.ah \
+		upParam_propErrT_x_simil_propErr.ah \
+		upParam_kalmanGain_x_propErr.ah \
+		MultHelixProp.ah \
+		MultHelixPropTransp.ah
+
+${AUTO_HEADERS}: auto-genmplex
+
+.INTERMEDIATE: auto-genmplex
 auto-genmplex: GenMPlexOps.pl
-	./GenMPlexOps.pl && touch $@
+	./GenMPlexOps.pl
 
-AUTO_TGTS := auto-matriplex auto-genmplex
+AUTO_TGTS := auto-matriplex ${AUTO_HEADERS}
 
+default: ${AUTO_TGTS} ${EXES}
 
 clean:
 	rm -f ${EXES} *.d *.o *.om 
 
 distclean: clean
 	rm -f *.optrpt
-	rm -f ${AUTO_TGTS} *.ah
+	rm -f ${AUTO_TGTS}
 
 echo:
 	@echo "CXX      = ${CXX}"
@@ -56,8 +66,6 @@ echo:
 
 
 ################################################################
-
--include *.d ../*.d
 
 # Should be a lib, really
 ABOVE_OBJS := $(patsubst %, ../%.o, Config Matrix Event Hit Track Propagation KalmanUtils Simulation Geometry SimpleGeom fittest buildtest ConformalUtils seedtest BinInfoUtils)
@@ -72,12 +80,15 @@ MKFOBJS := $(MKFSRCS:.cc=.o)
 
 ALLOBJS := ${MKFOBJS} ${ABOVE_OBJS}
 
-mkFit: ${AUTO_TGTS} ${ALLOBJS}
+ifeq ($(filter clean distclean, ${MAKECMDGOALS}),)
+include $(MKFSRCS:.cc=.d)
+endif
+
+mkFit: ${ALLOBJS}
 	${CXX} ${CXXFLAGS} ${VEC_HOST} ${LDFLAGS} ${ALLOBJS} -o $@ ${LDFLAGS_HOST}
 
-${MKFOBJS}: %.o: %.cc
+${MKFOBJS}: %.o: %.cc %.d
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${VEC_HOST} -c -o $@ $<
-
 
 ### MIC build, icc only
 
@@ -87,11 +98,11 @@ MKFOBJS_MIC := $(MKFOBJS:.o=.om)
 
 ALLOBJS_MIC := $(ALLOBJS:.o=.om) 
 
-mkFit-mic: ${AUTO_TGTS} ${ALLOBJS_MIC}
+mkFit-mic: ${ALLOBJS_MIC}
 	${CXX} ${CXXFLAGS} ${VEC_MIC} ${LDFLAGS_NO_ROOT} ${ALLOBJS_MIC} -o $@ ${LDFLAGS_MIC}
 	scp $@ mic0:
 
-${MKFOBJS_MIC}: %.om: %.cc
+${MKFOBJS_MIC}: %.om: %.cc %.d
 	${CXX} ${CPPFLAGS_NO_ROOT} ${CXXFLAGS} ${VEC_MIC} -c -o $@ $<
 
 endif


### PR DESCRIPTION
* Always use gcc for dependency generation.
* Requires explicit enumeration of auto-generated code fragments in mkFit/Makefile.

*NOTE:* make sure to remove mkFit/auto-genmplex file (or run make distclean before pulling in the change).