### PR TITLE
Real seeding smatrix

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -15,6 +15,9 @@ namespace Config
   constexpr float DegToRad = Config::PI / 180.0;
   constexpr double Sqrt2   = 1.4142135623730950488016887242097;
 
+  // general parameters of matrices
+  constexpr int nParams = 6;
+
   // config on main + mkFit
   constexpr int nTracks = 20000;
   constexpr int nEvents = 10;

--- a/Event.cc
+++ b/Event.cc
@@ -247,12 +247,15 @@ void Event::Fit()
 }
 
 void Event::Validate(int ievt){
+  // KM: Config tree just filled once... in main.cc
+  validation_.makeSimTkToRecoTksMaps(*this);
+  validation_.makeSeedTkToRecoTkMaps(*this);
   validation_.fillSegmentTree(segmentMap_,ievt);
   validation_.fillBranchTree(ievt);
-  validation_.makeSimTkToRecoTksMaps(*this);
-  validation_.fillEffTree(*this);
-  validation_.makeSeedTkToRecoTkMaps(*this);
+  validation_.fillEfficiencyTree(*this);
   validation_.fillFakeRateTree(*this);
+  validation_.fillGeometryTree(*this);
+  validation_.fillConformalTree(*this);
 }
 
 void Event::PrintStats(const TrackVec& trks, TrackExtraVec& trkextras)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ clean: clean-local
 distclean: clean-local
 	-rm -f ${AUTO_TGTS}
 	-rm -f *.optrpt
-	cd mkFit && ${MAKE} distclean
+	cd Matriplex && ${MAKE} distclean
+	cd mkFit     && ${MAKE} distclean
 
 main: ${AUTO_TGTS} ${OBJS} ${LIBUSOLIDS}
 	${CXX} ${CXXFLAGS} ${VEC_HOST} -o $@ ${OBJS} ${LIBUSOLIDS} ${LDFLAGS}

--- a/Makefile.config
+++ b/Makefile.config
@@ -91,7 +91,7 @@ USE_ETA_SEGMENTATION := -DETASEG
 GEN_FLAT_ETA := -DGENFLATETA
 
 # 16. Use inward fit in Conformal fit + final KF Fit
-#INWARD_FIT := -DINWARDFIT
+INWARD_FIT := -DINWARDFIT
 
 ################################################################
 # Derived settings

--- a/Makefile.config
+++ b/Makefile.config
@@ -104,7 +104,7 @@ LDFLAGS  := ${OSX_LDFLAGS}
 LDFLAGS_HOST :=
 LDFLAGS_MIC  :=
 
-CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${USE_ETA_SEGMENTATION} ${INWARD_FIT}
+CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${USE_ETA_SEGMENTATION} ${INWARD_FIT} ${GEN_FLAT_ETA}
 
 ifdef USE_VTUNE_NOTIFY
 ifdef VTUNE_AMPLIFIER_XE_2016_DIR
@@ -113,8 +113,6 @@ LDFLAGS_HOST += -L$(VTUNE_AMPLIFIER_XE_2016_DIR)/lib64 -littnotify
 LDFLAGS_MIC  += -L$(VTUNE_AMPLIFIER_XE_2016_DIR)/bin64/k1om -littnotify
 endif
 endif
-
-CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${USE_ETA_SEGMENTATION} ${GEN_FLAT_ETA}
 
 ifneq ($(CXX),icc)
   #CXXFLAGS += -Wall -Wno-unknown-pragmas
@@ -168,8 +166,14 @@ endif
 # Dependency generation
 ################################################################
 
+DEPEND_TGTS = -MQ '$(patsubst %.d,%.o,$@)'
+
+ifeq (${CXX},icc)
+  DEPEND_TGTS += -MQ '$(patsubst %.d,%.om,$@)'
+endif
+
 # Always use gcc as icc used to have trouble with this (? check if still true)
-MAKEDEPEND = gcc -MM -MG ${CPPFLAGS}
+MAKEDEPEND = gcc -MM -MG ${DEPEND_TGTS} ${CPPFLAGS}
 
 %.d: %.cc
 	${MAKEDEPEND} -o $@ $<

--- a/Matriplex/Makefile
+++ b/Matriplex/Makefile
@@ -5,6 +5,8 @@ auto: std_sym intr_sym
 clean:
 	rm -f *.ah
 
+distclean: clean
+
 # ---------------------------------------------------------------- #
 
 std_sym:  std_sym_3x3.ah std_sym_6x6.ah

--- a/PlotValidation.cpp
+++ b/PlotValidation.cpp
@@ -61,24 +61,890 @@ PlotValidation::~PlotValidation(){
   delete fTH2Canv;
 }
 
-void PlotValidation::Validation(Bool_t mvInput){
-  PlotValidation::PlotBranching();
-  PlotValidation::PlotSegment();
-  PlotValidation::PlotTiming();
-  PlotValidation::PlotSimGeo();  
-  PlotValidation::PlotNHits(); 
-  PlotValidation::PlotCFResidual();
-  PlotValidation::PlotCFResolutionPull();
-  PlotValidation::PlotPosResolutionPull(); 
-  PlotValidation::PlotMomResolutionPull();
+void PlotValidation::Validation(Bool_t fullVal, Bool_t mvInput){
   PlotValidation::PlotEfficiency(); 
   PlotValidation::PlotFakeRate();
   PlotValidation::PlotDuplicateRate();
+  PlotValidation::PlotNHits(); 
+  PlotValidation::PlotTiming();
+  PlotValidation::PlotMomResolutionPull();
+
+  if (fullVal) {
+    PlotValidation::PlotSegment();
+    PlotValidation::PlotBranching();
+    PlotValidation::PlotSimGeo();  
+    PlotValidation::PlotPosResolutionPull(); 
+    PlotValidation::PlotCFResidual();
+    PlotValidation::PlotCFResolutionPull();
+  }
+
   PlotValidation::PrintTotals();
   
-  if (mvInput){
+  if (mvInput) {
     PlotValidation::MoveInput();
   }
+}
+
+void PlotValidation::PlotEfficiency(){
+  // Get tree
+  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
+
+  // make output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "efficiency"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  //Declare strings for branches and plots
+  Bool_t  zeroSupLin = true;
+  TStrVec vars  = {"pt","eta","phi"};
+  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
+  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
+  IntVec nBins = {60,60,80};
+  FltVec  xlow  = {0,-3,-4};
+  FltVec  xhigh = {15,3,4};  
+
+  TStrVec trks  = {"seed","build","fit"};
+  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
+
+  // Floats/Ints to be filled for trees
+  FltVec mcvars_val(vars.size()); // first index is var. only for mc values! so no extra index 
+  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  
+  // Create plots
+  TH1FRefVecVec varsNumerPlot(vars.size());
+  TH1FRefVecVec varsDenomPlot(vars.size());
+  TH1FRefVecVec varsEffPlot(vars.size());
+  for (UInt_t i = 0; i < vars.size(); i++){
+    varsNumerPlot[i].resize(trks.size());
+    varsDenomPlot[i].resize(trks.size());
+    varsEffPlot[i].resize(trks.size());
+  }  
+
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      // Numerator
+      varsNumerPlot[i][j] = new TH1F(Form("h_sim_%s_numer_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Numer) Eff",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Denominator
+      varsDenomPlot[i][j] = new TH1F(Form("h_sim_%s_denom_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Denom) Eff",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Effiency
+      varsEffPlot[i][j] = new TH1F(Form("h_sim_%s_eff_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track Effiency vs MC %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsEffPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsEffPlot[i][j]->GetYaxis()->SetTitle("Efficiency");    
+    }
+  }
+
+  //Initialize var_val/err arrays, SetBranchAddress
+  for (UInt_t i = 0; i < vars.size(); i++){ // loop over trks index
+    // initialize var
+    mcvars_val[i] = 0.;
+    
+    //Set var+trk branch
+    efftree->SetBranchAddress(Form("%s_mc_gen",vars[i].Data()),&(mcvars_val[i]));
+  }
+  
+  //Initialize masks, set branch addresses  
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    mcmask_trk[j] = 0;
+    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+  }
+
+  // Fill histos, compute eff from tree branches 
+  for (Int_t k = 0; k < efftree->GetEntries(); k++){
+    efftree->GetEntry(k);
+    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
+      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+	varsDenomPlot[i][j]->Fill(mcvars_val[i]);
+	if (mcmask_trk[j] == 1){ // must be associated
+	  varsNumerPlot[i][j]->Fill(mcvars_val[i]);
+	} // must be a matched track for effiency
+      } // end loop over trks
+    } // end loop over vars
+  } // end loop over entry in tree
+
+  // Draw, divide, and save efficiency plots
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsEffPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
+      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsEffPlot[i][j],subdirname,Form("%s_eff_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
+      delete varsNumerPlot[i][j];
+      delete varsDenomPlot[i][j];
+      delete varsEffPlot[i][j];
+    }
+  }  
+  delete efftree;
+}
+
+void PlotValidation::PlotFakeRate(){
+  // Get tree
+  TTree * fakeratetree  = (TTree*)fInRoot->Get("fakeratetree");
+
+  // make output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "fakerate"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  //Declare strings for branches and plots
+  Bool_t  zeroSupLin = true;
+  TStrVec vars  = {"pt","eta","phi"};
+  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
+  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
+  IntVec nBins = {60,60,80};
+  FltVec  xlow  = {0,-3,-4};
+  FltVec  xhigh = {15,3,4};  
+
+  TStrVec trks  = {"seed","build","fit"};
+  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
+
+  // Floats/Ints to be filled for trees
+  FltVecVec recovars_val(vars.size()); // first index is var, second is type of track
+  for (UInt_t i = 0; i < vars.size(); i++){
+    recovars_val[i].resize(trks.size());
+  }
+
+  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  IntVec seedmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  
+  // Create FR plots
+  TH1FRefVecVec varsNumerPlot(vars.size());
+  TH1FRefVecVec varsDenomPlot(vars.size());
+  TH1FRefVecVec varsFRPlot(vars.size());
+  for (UInt_t i = 0; i < vars.size(); i++){
+    varsNumerPlot[i].resize(trks.size());
+    varsDenomPlot[i].resize(trks.size());
+    varsFRPlot[i].resize(trks.size());
+  }  
+
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      // Numerator
+      varsNumerPlot[i][j] = new TH1F(Form("h_reco_%s_numer_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track vs Reco %s (Numer) FR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Denominator
+      varsDenomPlot[i][j] = new TH1F(Form("h_reco_%s_denom_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track vs Reco %s (Denom) FR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Fake Rate
+      varsFRPlot[i][j] = new TH1F(Form("h_reco_%s_FR_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track Fake Rate vs Reco %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsFRPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsFRPlot[i][j]->GetYaxis()->SetTitle("Fake Rate");    
+    }
+  }
+
+  //Initialize var_val/err arrays, SetBranchAddress
+  for (UInt_t i = 0; i < vars.size(); i++){ // loop over vars index
+    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+      // initialize var
+      recovars_val[i][j] = 0.;
+    
+      //Set var+trk branch
+      fakeratetree->SetBranchAddress(Form("%s_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
+    }
+  }
+  
+  //Initialize masks, set branch addresses  
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    mcmask_trk[j] = 0;
+    seedmask_trk[j] = 0;
+    
+    fakeratetree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+    fakeratetree->SetBranchAddress(Form("seedmask_%s",trks[j].Data()),&(seedmask_trk[j]));
+  }
+
+  // Fill histos, compute fake rate from tree branches 
+  for (Int_t k = 0; k < fakeratetree->GetEntries(); k++){
+    fakeratetree->GetEntry(k);
+    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
+      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+	if (seedmask_trk[j] == 1) { // make sure it is actually a reco track matched to a seed
+	  varsDenomPlot[i][j]->Fill(recovars_val[i][j]); // all reco tracks fill denom
+	  if (mcmask_trk[j] == 0){ // only completely unassociated reco tracks enter FR
+	    varsNumerPlot[i][j]->Fill(recovars_val[i][j]);
+	  } // must be an unmatched track for FR
+	} // must be a real reco track for FR
+      } // end loop over trks
+    } // end loop over vars
+  } // end loop over entry in tree
+
+  // Draw, divide, and save fake rate plots --> then delete!
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsFRPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
+      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsFRPlot[i][j],subdirname,Form("%s_FR_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
+      delete varsNumerPlot[i][j];
+      delete varsDenomPlot[i][j];
+      delete varsFRPlot[i][j];
+    }
+  }  
+  delete fakeratetree;
+}
+
+void PlotValidation::PlotDuplicateRate(){
+  // Get tree
+  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
+
+  // make output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "duplicaterate"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  //Declare strings for branches and plots
+  Bool_t  zeroSupLin = true;
+  TStrVec vars  = {"pt","eta","phi"};
+  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
+  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
+  IntVec nBins = {60,60,80};
+  FltVec  xlow  = {0,-3,-4};
+  FltVec  xhigh = {15,3,4};  
+
+  TStrVec trks  = {"seed","build","fit"};
+  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
+
+  // Floats/Ints to be filled for trees
+  FltVec mcvars_val(vars.size()); // first index is var. only for mc values! so no extra index 
+  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  IntVec nTkMatches_trk(trks.size()); // need to know how many duplicates each mc track produces.  nDupl == 1 means one reco track
+  
+  // Create DR plots
+  TH1FRefVecVec varsNumerPlot(vars.size());
+  TH1FRefVecVec varsDenomPlot(vars.size());
+  TH1FRefVecVec varsDRPlot(vars.size());
+  for (UInt_t i = 0; i < vars.size(); i++){
+    varsNumerPlot[i].resize(trks.size());
+    varsDenomPlot[i].resize(trks.size());
+    varsDRPlot[i].resize(trks.size());
+  }  
+
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      // Numerator
+      varsNumerPlot[i][j] = new TH1F(Form("h_sim_%s_numer_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Numer) DR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Denominator
+      varsDenomPlot[i][j] = new TH1F(Form("h_sim_%s_denom_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Denom) DR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      // Duplicate Rate
+      varsDRPlot[i][j] = new TH1F(Form("h_sim_%s_DR_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track Duplicate Rate vs MC %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
+      varsDRPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
+      varsDRPlot[i][j]->GetYaxis()->SetTitle("Duplicate Rate");    
+    }
+  }
+
+  //Initialize var_val/err arrays, SetBranchAddress
+  for (UInt_t i = 0; i < vars.size(); i++){ // loop over trks index
+    // initialize var
+    mcvars_val[i] = 0.;
+    
+    //Set var+trk branch
+    efftree->SetBranchAddress(Form("%s_mc_gen",vars[i].Data()),&(mcvars_val[i]));
+  }
+
+  //Initialize masks, set branch addresses  
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    mcmask_trk[j] = 0;
+    nTkMatches_trk[j] = 0;
+    
+    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+    efftree->SetBranchAddress(Form("nTkMatches_%s",trks[j].Data()),&(nTkMatches_trk[j]));
+  }
+
+  // Fill histos, compute DR from tree branches 
+  for (Int_t k = 0; k < efftree->GetEntries(); k++){
+    efftree->GetEntry(k);
+    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
+      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+	if (mcmask_trk[j] == 1) {
+	  varsDenomPlot[i][j]->Fill(mcvars_val[i]);
+	  for (Int_t n = 0; n < nTkMatches_trk[j]; n++){
+	    varsNumerPlot[i][j]->Fill(mcvars_val[i]);
+	  } // fill n times sim track is matched. filled once is one sim to one reco.  filled twice is two reco to one sim
+	} // must be a matched track for proper denom
+      } // end loop over trks
+    } // end loop over vars
+  } // end loop over entry in tree
+
+  // Draw, divide, and save DR plots
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsDRPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
+      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
+      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsDRPlot[i][j],subdirname,Form("%s_DR_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
+      delete varsNumerPlot[i][j];
+      delete varsDenomPlot[i][j];
+      delete varsDRPlot[i][j];
+    }
+  }  
+  delete efftree;
+}
+
+void PlotValidation::PlotNHits(){
+  // Get tree --> can do this all with fake rate tree
+  TTree * fakeratetree = (TTree*)fInRoot->Get("fakeratetree");
+
+  // make output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "nHits"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  //Declare strings for branches and plots
+  Bool_t  zeroSupLin = false;
+  TStrVec trks  = {"seed","build","fit"};
+  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
+  TStrVec coll  = {"allreco","fake","allmatch","bestmatch"};
+  TStrVec scoll = {"All Reco","Fake","All Match","Best Match"};
+
+  // Floats/Ints to be filled for trees
+  IntVec nHits_trk(trks.size());
+  FltVec fracHitsMatched_trk(trks.size());
+  
+  // masks
+  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  IntVec seedmask_trk(trks.size()); // need to know if reco track associated to a seed track
+  IntVec iTkMatches_trk(trks.size()); 
+  
+  // Create plots
+  TH1FRefVecVec nHitsPlot(trks.size());
+  TH1FRefVecVec fracHitsMatchedPlot(trks.size());
+  for (UInt_t j = 0; j < trks.size(); j++){
+    nHitsPlot[j].resize(coll.size());
+    fracHitsMatchedPlot[j].resize(coll.size());
+  }
+
+  for (UInt_t j = 0; j < trks.size(); j++){
+    for (UInt_t c = 0; c < coll.size(); c++){
+      // Numerator only type plots only!
+      nHitsPlot[j][c] = new TH1F(Form("h_nHits_%s_%s",coll[c].Data(),trks[j].Data()),Form("%s %s Track vs nHits / Track",scoll[c].Data(),strks[j].Data()),11,0,11);
+      nHitsPlot[j][c]->GetXaxis()->SetTitle("nHits / Track");
+      nHitsPlot[j][c]->GetYaxis()->SetTitle("nTracks");    
+      nHitsPlot[j][c]->Sumw2();
+
+      fracHitsMatchedPlot[j][c] = new TH1F(Form("h_fracHitsMatched_%s_%s",coll[c].Data(),trks[j].Data()),Form("%s %s Track vs Highest Fraction of Matched Hits / Track",scoll[c].Data(),strks[j].Data()),4000,0,1.1);
+      fracHitsMatchedPlot[j][c]->GetXaxis()->SetTitle("Highest Fraction of Matched Hits / Track");
+      fracHitsMatchedPlot[j][c]->GetYaxis()->SetTitle("nTracks");    
+      fracHitsMatchedPlot[j][c]->Sumw2();
+    }
+  }
+
+  //Initialize masks and variables, set branch addresses  
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    mcmask_trk[j]          = 0;
+    seedmask_trk[j]        = 0;
+    iTkMatches_trk[j]      = 0;
+    nHits_trk[j]           = 0;
+    fracHitsMatched_trk[j] = 0;
+
+    fakeratetree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+    fakeratetree->SetBranchAddress(Form("seedmask_%s",trks[j].Data()),&(seedmask_trk[j]));
+    fakeratetree->SetBranchAddress(Form("iTkMatches_%s",trks[j].Data()),&(iTkMatches_trk[j]));
+    fakeratetree->SetBranchAddress(Form("nHits_%s",trks[j].Data()),&(nHits_trk[j]));
+    fakeratetree->SetBranchAddress(Form("fracHitsMatched_%s",trks[j].Data()),&(fracHitsMatched_trk[j]));
+  }
+
+  // Fill histos, compute res/pull from tree branches 
+  for (Int_t k = 0; k < fakeratetree->GetEntries(); k++){
+    fakeratetree->GetEntry(k);
+    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+      for (UInt_t c = 0; c < coll.size(); c++){ // loop over trk collection type
+	if (c == 0) { // all reco
+	  if (seedmask_trk[j] == 1){
+	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
+	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
+	  }
+	}
+	else if (c == 1) { // fake 
+	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 0)) { 
+	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
+	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
+	  }
+	}
+	else if (c == 2) { // all matches  
+	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 1)) {
+	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
+	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
+	  }
+	}
+	else if (c == 3) { // best matches only	  
+	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 1) && (iTkMatches_trk[j] == 0)) {
+	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
+	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
+	  }
+	}
+      } // end loop over trk type collection
+    } // end loop over trks
+  } // end loop over entry in tree
+  
+  // Draw and save nHits plots
+  for (UInt_t j = 0; j < trks.size(); j++){
+    for (UInt_t c = 0; c < coll.size(); c++){ // loop over trk collection type
+      PlotValidation::DrawWriteSaveTH1FPlot(subdir,nHitsPlot[j][c],subdirname,Form("nHits_%s_%s",coll[c].Data(),trks[j].Data()),zeroSupLin);
+      PlotValidation::DrawWriteSaveTH1FPlot(subdir,fracHitsMatchedPlot[j][c],subdirname,Form("fracHitsMatched_%s_%s",coll[c].Data(),trks[j].Data()),zeroSupLin);
+      
+      delete nHitsPlot[j][c];
+      delete fracHitsMatchedPlot[j][c];
+    }
+  }  
+    
+  delete fakeratetree;
+}
+
+void PlotValidation::PlotTiming(){
+  // get input tree
+  TTree * configtree = (TTree*)fInRoot->Get("configtree");
+
+  // labels for histos (x-axis)
+  TStrVec stime = {"Simulate","Segment","Seed","Build","Fit","Validate"};
+
+  // make subdirectory
+  TString subdirname = "timing"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+  
+  // output plots
+  Bool_t zeroSupLin = true;
+
+  // make new timing plots
+  TH1F * tottime = new TH1F("h_total_timing","Total Time Spent in Simulation",6,0,6);
+  tottime->GetXaxis()->SetTitle("Event Function Call");
+  tottime->GetYaxis()->SetTitle("Time [s]");
+  tottime->SetStats(0);
+  tottime->Sumw2();
+  for (Int_t t = 1; t <= tottime->GetNbinsX(); t++){
+    tottime->GetXaxis()->SetBinLabel(t,stime[t-1].Data());
+  }
+  
+  TH1F * rectime = new TH1F("h_reco_timing_norm","Normalized Time Spent in Reconstruction",4,0,4);
+  tottime->GetXaxis()->SetTitle("Event Function Call");
+  rectime->GetYaxis()->SetTitle("Fraction of Time in Reco");
+  rectime->SetStats(0);
+  rectime->Sumw2();
+  for (Int_t t = 1; t <= rectime->GetNbinsX(); t++){
+    rectime->GetXaxis()->SetBinLabel(t,stime[t].Data());
+  }
+  
+  Float_t simtime = 0., segtime = 0., seedtime = 0., buildtime = 0., fittime = 0., hlvtime = 0.;
+  configtree->SetBranchAddress("simtime",&simtime);
+  configtree->SetBranchAddress("segtime",&segtime);
+  configtree->SetBranchAddress("seedtime",&seedtime);
+  configtree->SetBranchAddress("buildtime",&buildtime);
+  configtree->SetBranchAddress("fittime",&fittime);
+  configtree->SetBranchAddress("hlvtime",&hlvtime);
+  configtree->GetEntry(0);
+  
+  // fill histos
+  tottime->SetBinContent(1,simtime);
+  tottime->SetBinContent(2,segtime);
+  tottime->SetBinContent(3,seedtime);
+  tottime->SetBinContent(4,buildtime);
+  tottime->SetBinContent(5,fittime);
+  tottime->SetBinContent(6,hlvtime);
+  
+  rectime->SetBinContent(1,segtime);
+  rectime->SetBinContent(2,seedtime);
+  rectime->SetBinContent(3,buildtime);
+  rectime->SetBinContent(4,fittime);
+  
+  // normalize rec time
+  rectime->Scale(1.0/rectime->Integral());
+  
+  // draw and save stuff
+  PlotValidation::DrawWriteSaveTH1FPlot(subdir,tottime,subdirname,"total_time_sim",zeroSupLin);
+  PlotValidation::DrawWriteSaveTH1FPlot(subdir,rectime,subdirname,"norm_time_reco",zeroSupLin);
+
+  delete tottime;
+  delete rectime;
+  
+  delete configtree;
+}
+
+void PlotValidation::PlotMomResolutionPull(){
+  // Get tree
+  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
+
+  // make  output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "momentum_resolutionpull"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
+  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  //Declare strings for branches and plots
+  TStrVec vars      = {"pt","eta","phi"};
+  TStrVec evars     = {"ept","eeta","ephi"};
+  TStrVec svars     = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
+  TStrVec sunits    = {" [GeV/c]","",""}; // units --> labels for histograms for given variable
+  IntVec nBinsRes  = {100,100,100};
+  FltVec  xlowRes   = {-0.5,-0.5,-0.5};
+  FltVec  xhighRes  = {0.5,0.5,0.5};  
+  FltVec  gausRes   = {0.3,0.3,0.3}; // symmetric bounds for gaussian fit
+  IntVec nBinsPull = {100,100,100};
+  FltVec  xlowPull  = {-5,-5,-5};
+  FltVec  xhighPull = {5,5,5};  
+  FltVec  gausPull  = {3,3,3}; // symmetric bounds for gaussian fit
+
+  TStrVec trks      = {"seed","build","fit"};
+  TStrVec strks     = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
+
+  // Floats/Ints to be filled for trees
+  FltVecVec mcvars_val(vars.size());
+  IntVec    mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  FltVecVec recovars_val(vars.size()); // first index is nVars, second is nTrkTypes
+  FltVecVec recovars_err(vars.size());
+  for (UInt_t i = 0; i < vars.size(); i++){
+    mcvars_val[i].resize(trks.size());
+    recovars_val[i].resize(trks.size());
+    recovars_err[i].resize(trks.size());
+  }
+  FltVec vars_out = {0.,0.}; // res/pull output
+  
+  // Create pos plots
+  TH1FRefVecVec varsResPlot(vars.size());
+  TH1FRefVecVec varsPullPlot(vars.size());
+  for (UInt_t i = 0; i < vars.size(); i++){
+    varsResPlot[i].resize(trks.size());
+    varsPullPlot[i].resize(trks.size());
+  }
+
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      //Res
+      varsResPlot[i][j] = new TH1F(Form("h_%s_res_%s",vars[i].Data(),trks[j].Data()),Form("%s Resolution (%s Track vs. MC Track)",svars[i].Data(),strks[j].Data()),nBinsRes[i],xlowRes[i],xhighRes[i]);
+      varsResPlot[i][j]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/%s^{mc}%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data()));
+      varsResPlot[i][j]->GetYaxis()->SetTitle("nTracks");
+      varsResPlot[i][j]->Sumw2();
+
+      //Pull
+      varsPullPlot[i][j] = new TH1F(Form("h_%s_pull_%s",vars[i].Data(),trks[j].Data()),Form("%s Pull (%s Track vs. MC Track)",svars[i].Data(),strks[j].Data()),nBinsPull[i],xlowPull[i],xhighPull[i]);
+      varsPullPlot[i][j]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/#sigma(%s^{%s})%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),strks[j].Data(),sunits[i].Data()));
+      varsPullPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
+      varsPullPlot[i][j]->Sumw2();
+    }
+  }
+
+  //Initialize var_val/err arrays, SetBranchAddress
+  for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
+    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+      // initialize var + errors
+      mcvars_val[i][j] = 0.;
+      recovars_val[i][j] = 0.;
+      recovars_err[i][j] = 0.;
+      
+      //Set var+trk branch
+      efftree->SetBranchAddress(Form("%s_mc_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
+      efftree->SetBranchAddress(Form("%s_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
+      efftree->SetBranchAddress(Form("%s_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[i][j]));
+    }
+  }
+  
+  //Initialize masks, set branch addresses  
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    mcmask_trk[j] = 0;
+    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+  }
+
+  // Fill histos, compute res/pull from tree branches 
+  for (Int_t k = 0; k < efftree->GetEntries(); k++){
+    efftree->GetEntry(k);
+    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
+      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+	if (mcmask_trk[j] == 1){ // must be associated
+	  PlotValidation::ComputeResolutionPull(mcvars_val[i][j],recovars_val[i][j],recovars_err[i][j],vars_out);
+	  if (!isnan(vars_out[0])){ // fill if not nan
+	    varsResPlot[i][j]->Fill(vars_out[0]);
+	  }
+	  if (!isnan(vars_out[1])){ // fill if not nan
+	    varsPullPlot[i][j]->Fill(vars_out[1]);
+	  }
+	} // must be a matched track to make resolution plots
+      } // end loop over trks
+    } // end loop over vars
+  } // end loop over entry in tree
+
+  // Draw, fit, and save plots
+  for (UInt_t i = 0; i < vars.size(); i++){
+    for (UInt_t j = 0; j < trks.size(); j++){
+      PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsResPlot[i][j],subdirname,Form("%s_resolution_%s",vars[i].Data(),trks[j].Data()),gausRes[i]);
+      PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsPullPlot[i][j],subdirname,Form("%s_pull_%s",vars[i].Data(),trks[j].Data()),gausPull[i]);
+      delete varsResPlot[i][j];
+      delete varsPullPlot[i][j];
+    }
+  }  
+  delete efftree;
+}
+
+void PlotValidation::PlotSegment(){
+  // Get trees and set addresses
+  TTree * segtree = (TTree*)fInRoot->Get("segtree");
+  
+  Int_t event  = 0;
+  Int_t layer  = 0;
+  Int_t etabin = 0;
+  Int_t phibin = 0;
+  Int_t nHits  = 0;
+  
+  segtree->SetBranchAddress("evtID",&event);
+  segtree->SetBranchAddress("layer",&layer);
+  segtree->SetBranchAddress("etabin",&etabin);
+  segtree->SetBranchAddress("phibin",&phibin);
+  segtree->SetBranchAddress("nHits",&nHits);
+  
+  // get config info
+  TTree * configtree = (TTree*)fInRoot->Get("configtree");
+  Int_t nEvents  = 0;
+  Int_t nLayers  = 0;
+  Int_t nEtaPart = 0;
+  Int_t nPhiPart = 0;
+  configtree->SetBranchAddress("Nevents",&nEvents);
+  configtree->SetBranchAddress("nLayers",&nLayers);
+  configtree->SetBranchAddress("nEtaPart",&nEtaPart);
+  configtree->SetBranchAddress("nPhiPart",&nPhiPart);
+  configtree->GetEntry(0);
+
+  ////////////////////////////////////////
+  // Store the info in relevant vectors //
+  ////////////////////////////////////////
+
+  // initialize the relevant vectors here
+  FltVecVec    nHitsEtaVV(nLayers); // vector to store how many hits in given eta bin (sum over the phi bins)
+  FltVecVecVec nHitsPhiVVV(nLayers); // vector to store how many hits in given eta-phi bin
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    nHitsEtaVV[ilay].resize(nEtaPart);
+    nHitsPhiVVV[ilay].resize(nEtaPart);
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      nHitsEtaVV[ilay][ieta] = 0;
+      nHitsPhiVVV[ilay][ieta].resize(nPhiPart);
+      for (Int_t iphi = 0; iphi < nPhiPart; iphi++){
+	nHitsPhiVVV[ilay][ieta][iphi] = 0;
+      }
+    }
+  }
+
+  // just fill the eta-phi bin vector, and then sum over phi bins for the eta vector
+  for (Int_t i = 0; i < segtree->GetEntries(); i++) {
+    segtree->GetEntry(i);
+    nHitsPhiVVV[layer][etabin][phibin] += nHits;     
+  }
+
+  // sum over phi bins into eta bin vector
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      for (Int_t iphi = 0; iphi < nPhiPart; iphi++){
+	nHitsEtaVV[ilay][ieta] += nHitsPhiVVV[ilay][ieta][iphi];
+      }
+    }
+  }
+  
+  // average over events
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      nHitsEtaVV[ilay][ieta] /= nEvents;
+      for (Int_t iphi = 0; iphi < nPhiPart; iphi++){
+	nHitsPhiVVV[ilay][ieta][iphi] /= nEvents;
+      }
+    }
+  }
+
+  // initialize plot vectors
+  TH1FRefVec    nHitsplots(nLayers);
+  TH1FRefVec    etabinplots(nLayers);
+  TH1FRefVecVec phibinplots(nLayers);
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    phibinplots[ilay].resize(nEtaPart);
+  }
+
+  // make output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "segment"; 
+  PlotValidation::MakeSubDirectory(subdirname);
+  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
+  subdir->cd();
+
+  // new and fill!
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    nHitsplots[ilay] = new TH1F(Form("h_nHits_perEtaPhiBin_lay%u",ilay),Form("nHits per EtaPhiBin (Layer: %u)",ilay),20,0,20);
+    nHitsplots[ilay]->GetXaxis()->SetTitle("nHits per EtaPhiBin");
+    nHitsplots[ilay]->GetYaxis()->SetTitle("nEtaPhiBins");
+    
+    etabinplots[ilay] = new TH1F(Form("h_nHits_vs_etabin_lay%u",ilay),Form("nHits vs EtaBin (Layer: %u)",ilay),nEtaPart,0,nEtaPart);
+    etabinplots[ilay]->GetXaxis()->SetTitle("Eta Bin Number");
+    etabinplots[ilay]->GetYaxis()->SetTitle("nHits in Eta Bin");
+
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      //fill the eta bin plots
+      etabinplots[ilay]->SetBinContent(ieta+1,nHitsEtaVV[ilay][ieta]);
+
+      // eta-phi bin plots new
+      phibinplots[ilay][ieta] = new TH1F(Form("h_nHits_vs_phibin_lay%u_eta%u",ilay,ieta),Form("nHits vs PhiBin (Layer: %u, EtaBin: %u)",ilay,ieta),nPhiPart,0,nPhiPart);
+      phibinplots[ilay][ieta]->GetXaxis()->SetTitle("Phi Bin Number");
+      phibinplots[ilay][ieta]->GetYaxis()->SetTitle("nHits in Phi Bin");
+
+      // fill eta-phi bin plots
+      for (Int_t iphi = 0; iphi < nPhiPart; iphi++){
+	phibinplots[ilay][ieta]->SetBinContent(iphi+1,nHitsPhiVVV[ilay][ieta][iphi]);
+	nHitsplots[ilay]->Fill(nHitsPhiVVV[ilay][ieta][iphi]);
+      }
+    }
+  }
+
+  // write out the individual plots to the root file
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    PlotValidation::WriteTH1FPlot(subdir,nHitsplots[ilay]);
+    PlotValidation::WriteTH1FPlot(subdir,etabinplots[ilay]);
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      PlotValidation::WriteTH1FPlot(subdir,phibinplots[ilay][ieta]);
+    }
+  }
+
+  ///////////////////////////////
+  // Plot segment results here //
+  ///////////////////////////////
+
+  // first do the nHits plot
+  fTH1Canv->cd();
+  fTH1Canv->SetLogy(0);
+
+  Float_t max = 0;
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    Float_t tmpmax = nHitsplots[ilay]->GetBinContent(nHitsplots[ilay]->GetMaximumBin());
+    if (tmpmax > max) {
+      max = tmpmax;
+    }
+  }
+  
+  // overplot
+  TLegend * legnhit = new TLegend(0.75,0.7,0.9,0.9);
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    nHitsplots[ilay]->SetStats(0);
+    nHitsplots[ilay]->SetTitle("Average nHits per Event per EtaPhiBin for All Layers"); 
+    nHitsplots[ilay]->SetMaximum(1.1*max);
+    nHitsplots[ilay]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
+    nHitsplots[ilay]->SetLineWidth(2);
+    nHitsplots[ilay]->Draw((ilay>0)?"SAME":"");
+    legnhit->AddEntry(nHitsplots[ilay],Form("Layer %u",ilay),"L");
+  }
+  legnhit->Draw("SAME");
+  fTH1Canv->SaveAs(Form("%s/%s/nHits_perEtaPhiBin_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
+    delete nHitsplots[ilay];
+  }
+  delete legnhit;
+
+  // now we want to overplot the eta plots second
+  max = 0;
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    Float_t tmpmax = etabinplots[ilay]->GetBinContent(etabinplots[ilay]->GetMaximumBin());
+    if (tmpmax > max) {
+      max = tmpmax;
+    }
+  }
+  
+  // overplot
+  TLegend * legeta = new TLegend(0.75,0.7,0.9,0.9);
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    etabinplots[ilay]->SetStats(0);
+    etabinplots[ilay]->SetTitle("Average nHits per Event vs EtaBin for All Layers"); 
+    etabinplots[ilay]->SetMaximum(1.1*max);
+    etabinplots[ilay]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
+    etabinplots[ilay]->SetLineWidth(2);
+    etabinplots[ilay]->Draw((ilay>0)?"SAME":"");
+    legeta->AddEntry(etabinplots[ilay],Form("Layer %u",ilay),"L");
+  }
+  legeta->Draw("SAME");
+  fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Etabin_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
+    delete etabinplots[ilay];
+  }
+  delete legeta;
+
+  // now we want to overplot the phi plots second ... a bit more complicated
+  // first do the phi bin plots for a given eta bin, overplot layer
+  // then  do the phi bin plots for a given layer, overplot eta bin
+
+  // so fix the eta bin, then overplot layers
+  for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+    Float_t max = 0;
+    for (Int_t ilay = 0; ilay < nLayers; ilay++){
+      Float_t tmpmax = phibinplots[ilay][ieta]->GetBinContent(phibinplots[ilay][ieta]->GetMaximumBin());
+      if (tmpmax > max) {
+	max = tmpmax;
+      }
+    }
+  
+    // overplot
+    TLegend * legphi = new TLegend(0.75,0.7,0.9,0.9);
+    for (Int_t ilay = 0; ilay < nLayers; ilay++){
+      phibinplots[ilay][ieta]->SetStats(0);
+      phibinplots[ilay][ieta]->SetTitle(Form("Average nHits per Event vs PhiBin for All Layers (EtaBin: %u)",ieta)); 
+      phibinplots[ilay][ieta]->SetMaximum(1.1*max);
+      phibinplots[ilay][ieta]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
+      phibinplots[ilay][ieta]->SetLineWidth(2);
+      phibinplots[ilay][ieta]->Draw((ilay>0)?"SAME":"");
+      legphi->AddEntry(phibinplots[ilay][ieta],Form("Layer %u",ilay),"L");
+    }
+    legphi->Draw("SAME");
+    fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Phibin_allLayers_etabin%u.%s",fOutName.Data(),subdirname.Data(),ieta,fOutType.Data()));    
+    delete legphi;
+  }  
+  
+  // now fix layer, overplot eta bins
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    Float_t max = 0;
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      Float_t tmpmax = phibinplots[ilay][ieta]->GetBinContent(phibinplots[ilay][ieta]->GetMaximumBin());
+      if (tmpmax > max) {
+	max = tmpmax;
+      }
+    }
+  
+    // overplot
+    TLegend * legphi = new TLegend(0.75,0.7,0.9,0.9);
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      phibinplots[ilay][ieta]->SetStats(0);
+      phibinplots[ilay][ieta]->SetTitle(Form("Average nHits per Event vs PhiBin for All EtaBins (Layer: %u)",ilay)); 
+      phibinplots[ilay][ieta]->SetMaximum(1.1*max);
+      phibinplots[ilay][ieta]->SetLineColor(fColors[ieta%fColorSize]+(ieta/fColorSize)); // allow colors to loop over base!
+      phibinplots[ilay][ieta]->SetLineWidth(2);
+      phibinplots[ilay][ieta]->Draw((ieta>0)?"SAME":"");
+      legphi->AddEntry(phibinplots[ilay][ieta],Form("EtaBin %u",ieta),"L");
+    }
+    legphi->Draw("SAME");
+    fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Phibin_allEtaBins_layer%u.%s",fOutName.Data(),subdirname.Data(),ilay,fOutType.Data()));    
+    delete legphi;
+  }  
+  
+  for (Int_t ilay = 0; ilay < nLayers; ilay++){
+    for (Int_t ieta = 0; ieta < nEtaPart; ieta++){
+      delete phibinplots[ilay][ieta];
+    }
+  }
+
+  delete configtree;
+  delete segtree;
 }
 
 void PlotValidation::PlotBranching(){
@@ -87,9 +953,9 @@ void PlotValidation::PlotBranching(){
   
   // Get config tree for printing out info
   TTree * configtree = (TTree*)fInRoot->Get("configtree"); // use to get nLayers
-  UInt_t  nLayers = 0;
-  UInt_t  nlayers_per_seed = 0;
-  UInt_t  nEvents = 0;
+  Int_t  nLayers = 0;
+  Int_t  nlayers_per_seed = 0;
+  Int_t  nEvents = 0;
   configtree->SetBranchAddress("nLayers",&nLayers);
   configtree->SetBranchAddress("nlayers_per_seed",&nlayers_per_seed);
   configtree->SetBranchAddress("Nevents",&nEvents);
@@ -140,7 +1006,7 @@ void PlotValidation::PlotBranching(){
   TH1FRefVec etaphibins_percand(nLayers);
   TH1FRefVec hits_percand(nLayers);
 
-  for (UInt_t layer = 0; layer < nLayers; layer++){
+  for (Int_t layer = 0; layer < nLayers; layer++){
     etaphibins_percand[layer] = new TH1F(Form("h_etaphibins_percand_lay%u",layer),Form("Average nEtaPhiBins per InputCand per Event (Layer %u)",layer),20,0,20);
     etaphibins_percand[layer]->GetXaxis()->SetTitle("nEtaPhiBins Explored per InputCand / Seed");
     etaphibins_percand[layer]->GetYaxis()->SetTitle("Cands");
@@ -162,7 +1028,7 @@ void PlotValidation::PlotBranching(){
 
   TH1FRefVec layNSigmaDeta(nLayers);
   TH1FRefVec layNSigmaDphi(nLayers);
-  for (UInt_t l = 0; l < nLayers; l++){
+  for (Int_t l = 0; l < nLayers; l++){
     layNSigmaDeta[l] = new TH1F(Form("h_lay_%u_nSigmaDeta",l),Form("Layer %u n#sigma_{#eta}#timesd#eta",l),100,0.0,0.1);
     layNSigmaDeta[l]->GetXaxis()->SetTitle("n#sigma_{#eta}#timesd#eta / Layer / Seed");
     layNSigmaDeta[l]->GetYaxis()->SetTitle("nInputCands");
@@ -173,20 +1039,20 @@ void PlotValidation::PlotBranching(){
   }
 
   // see comment in plotsimgeo about vectors. set up branches here
-  UIntVecRef candEtaPhiBins = 0;
-  UIntVecRef candHits       = 0;
-  UIntVecRef candBranches   = 0;
+  IntVecRef candEtaPhiBins = 0;
+  IntVecRef candHits       = 0;
+  IntVecRef candBranches   = 0;
 
-  UInt_t layer  = 0;
-  UInt_t nCands = 0;
+  Int_t layer  = 0;
+  Int_t nCands = 0;
 
-  UInt_t nCandEtaPhiBins = 0; // sum of vector
-  UInt_t nCandHits       = 0; // sum of vector
-  UInt_t nCandBranches   = 0; // sum of vector 
+  Int_t nCandEtaPhiBins = 0; // sum of vector
+  Int_t nCandHits       = 0; // sum of vector
+  Int_t nCandBranches   = 0; // sum of vector 
 
-  UInt_t uniqueEtaPhiBins = 0;
-  UInt_t uniqueHits = 0;
-  UInt_t uniqueBranches = 0;
+  Int_t uniqueEtaPhiBins = 0;
+  Int_t uniqueHits = 0;
+  Int_t uniqueBranches = 0;
   
   FltVecRef  candnSigmaDeta = 0;
   FltVecRef  candnSigmaDphi = 0;
@@ -205,17 +1071,17 @@ void PlotValidation::PlotBranching(){
   tree_br->SetBranchAddress("candnSigmaDeta",&candnSigmaDeta);
   tree_br->SetBranchAddress("candnSigmaDphi",&candnSigmaDphi);
 
-  UInt_t seedID = 0;
+  Int_t seedID = 0;
   tree_br->SetBranchAddress("seedID",&seedID);
 
-  for (UInt_t k = 0; k < (UInt_t) tree_br->GetEntries(); k++){
+  for (Int_t k = 0; k < tree_br->GetEntries(); k++){
     tree_br->GetEntry(k);
 
     nCandEtaPhiBins = 0; 
     nCandHits       = 0;
     nCandBranches   = 0; 
 
-    for (UInt_t c = 0; c < nCands; c++){ // cands (unless we really screwed up) equals candBranches.size() == candHits.size()
+    for (Int_t c = 0; c < nCands; c++){ // cands (unless we really screwed up) equals candBranches.size() == candHits.size()
       layNSigmaDeta[layer]->Fill((*candnSigmaDeta)[c]);
       layNSigmaDphi[layer]->Fill((*candnSigmaDphi)[c]);
 
@@ -246,7 +1112,7 @@ void PlotValidation::PlotBranching(){
   ////////////////////////////////////////////////////
   
   // write out the individual plots to the root file ... scale first to nEvents, then input cands
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
     PlotValidation::WriteTH1FPlot(subdir,etaphibins_percand[ilay]);
     PlotValidation::WriteTH1FPlot(subdir,hits_percand[ilay]);
 
@@ -260,7 +1126,7 @@ void PlotValidation::PlotBranching(){
   fTH1Canv->SetLogy(0);
 
   Float_t max = 0;
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
     Float_t tmpmax = etaphibins_percand[ilay]->GetBinContent(etaphibins_percand[ilay]->GetMaximumBin());
     if (tmpmax > max) {
       max = tmpmax;
@@ -269,7 +1135,7 @@ void PlotValidation::PlotBranching(){
   
   // overplot
   TLegend * legetaphibins = new TLegend(0.75,0.7,0.9,0.9);
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
     etaphibins_percand[ilay]->SetStats(0);
     etaphibins_percand[ilay]->SetTitle("EtaPhiBins per InputCand for All Layers (Normalized)"); 
     etaphibins_percand[ilay]->SetMaximum(1.1*max);
@@ -280,14 +1146,14 @@ void PlotValidation::PlotBranching(){
   }
   legetaphibins->Draw("SAME");
   fTH1Canv->SaveAs(Form("%s/%s/normalized_etaphibins_percand_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
     delete etaphibins_percand[ilay];
   }
   delete legetaphibins;
 
   // second do the nhits plots
   max = 0;
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
     Float_t tmpmax = hits_percand[ilay]->GetBinContent(hits_percand[ilay]->GetMaximumBin());
     if (tmpmax > max) {
       max = tmpmax;
@@ -296,7 +1162,7 @@ void PlotValidation::PlotBranching(){
   
   // overplot
   TLegend * leghits = new TLegend(0.75,0.7,0.9,0.9);
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){
     hits_percand[ilay]->SetStats(0);
     hits_percand[ilay]->SetTitle("Hits per InputCand for All Layers (Normalized)"); 
     hits_percand[ilay]->SetMaximum(1.1*max);
@@ -307,16 +1173,16 @@ void PlotValidation::PlotBranching(){
   }
   leghits->Draw("SAME");
   fTH1Canv->SaveAs(Form("%s/%s/normalized_nhits_percand_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
-  for (UInt_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
+  for (Int_t ilay = nlayers_per_seed; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
     delete hits_percand[ilay];
   }
   delete leghits;
 
   // Loop over layers first, then sum up entries in each bin stepping left to right (INCLUDE OVERFLOW!)
   // root conventions means we have vectors offset by 1
-  UIntVec etaphibins_laycount(nLayers+1);
-  UIntVec hits_laycount(nLayers+1); 
-  UIntVec branches_laycount(nLayers+1); 
+  IntVec etaphibins_laycount(nLayers+1);
+  IntVec hits_laycount(nLayers+1); 
+  IntVec branches_laycount(nLayers+1); 
 
   for (Int_t lay = 1; lay <= Int_t(nLayers); lay++){
     etaphibins_laycount[lay] = 0;
@@ -393,7 +1259,7 @@ void PlotValidation::PlotBranching(){
 
   max = 0.0;
   // write the bare plots, scale, and get max and min
-  for (UInt_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
+  for (Int_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
     PlotValidation::WriteTH1FPlot(subdir,layNSigmaDeta[l]);
     layNSigmaDeta[l]->Scale(1.0/layNSigmaDeta[l]->Integral());
     Float_t tmpmax = layNSigmaDeta[l]->GetBinContent(layNSigmaDeta[l]->GetMaximumBin());
@@ -402,7 +1268,7 @@ void PlotValidation::PlotBranching(){
     }
   }
   TLegend * legeta = new TLegend(0.75,0.7,0.9,0.9);
-  for (UInt_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation and overplot
+  for (Int_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation and overplot
     fTH1Canv->cd();    
     layNSigmaDeta[l]->SetStats(0);
     layNSigmaDeta[l]->SetTitle("n#sigma_{#eta}#timesd#eta for All Layers (Normalized)"); 
@@ -416,13 +1282,13 @@ void PlotValidation::PlotBranching(){
   legeta->Draw("SAME");
   fTH1Canv->SetLogy(1);
   fTH1Canv->SaveAs(Form("%s/%s/nSigmaDeta_layers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));      
-  for (UInt_t l = 0; l < nLayers; l++){ // delete all histos, including layers not filled in
+  for (Int_t l = 0; l < nLayers; l++){ // delete all histos, including layers not filled in
     delete layNSigmaDeta[l];
   }
   delete legeta;
 
   max = 0;
-  for (UInt_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
+  for (Int_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
     PlotValidation::WriteTH1FPlot(subdir,layNSigmaDphi[l]);
     layNSigmaDphi[l]->Scale(1.0/layNSigmaDphi[l]->Integral());
     Float_t tmpmax = layNSigmaDphi[l]->GetBinContent(layNSigmaDphi[l]->GetMaximumBin());
@@ -432,7 +1298,7 @@ void PlotValidation::PlotBranching(){
   }
   TLegend * legphi = new TLegend(0.75,0.7,0.9,0.9);
   // normalize all nsigma distributions automatically and write them
-  for (UInt_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
+  for (Int_t l = nlayers_per_seed; l < nLayers; l++){ // only fill ones with actual propagation
     fTH1Canv->cd();
     layNSigmaDphi[l]->SetStats(0);
     layNSigmaDphi[l]->SetTitle("n#sigma_{#phi}#timesd#phi for All Layers (Normalized)"); 
@@ -446,7 +1312,7 @@ void PlotValidation::PlotBranching(){
   legphi->Draw("SAME");
   fTH1Canv->SetLogy(1);
   fTH1Canv->SaveAs(Form("%s/%s/nSigmaDphi_layers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
-  for (UInt_t l = 0; l < nLayers; l++){ // delete all histos, including layers not filled in
+  for (Int_t l = 0; l < nLayers; l++){ // delete all histos, including layers not filled in
     delete layNSigmaDphi[l];
   }
   delete legphi;
@@ -473,330 +1339,9 @@ void PlotValidation::PlotBranching(){
   delete tree_br;
 }
 
-void PlotValidation::PlotTiming(){
-  // get input tree
-  TTree * configtree = (TTree*)fInRoot->Get("configtree");
-
-  // labels for histos (x-axis)
-  TStrVec stime = {"Simulate","Segment","Seed","Build","Fit","Validate"};
-
-  // make subdirectory
-  TString subdirname = "timing"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-  
-  // output plots
-  Bool_t zeroSupLin = true;
-
-  // make new timing plots
-  TH1F * tottime = new TH1F("h_total_timing","Total Time Spent in Simulation",6,0,6);
-  tottime->GetXaxis()->SetTitle("Event Function Call");
-  tottime->GetYaxis()->SetTitle("Time [s]");
-  tottime->SetStats(0);
-  tottime->Sumw2();
-  for (Int_t t = 1; t <= tottime->GetNbinsX(); t++){
-    tottime->GetXaxis()->SetBinLabel(t,stime[t-1].Data());
-  }
-  
-  TH1F * rectime = new TH1F("h_reco_timing_norm","Normalized Time Spent in Reconstruction",4,0,4);
-  tottime->GetXaxis()->SetTitle("Event Function Call");
-  rectime->GetYaxis()->SetTitle("Fraction of Time in Reco");
-  rectime->SetStats(0);
-  rectime->Sumw2();
-  for (Int_t t = 1; t <= rectime->GetNbinsX(); t++){
-    rectime->GetXaxis()->SetBinLabel(t,stime[t].Data());
-  }
-  
-  Float_t simtime = 0., segtime = 0., seedtime = 0., buildtime = 0., fittime = 0., hlvtime = 0.;
-  configtree->SetBranchAddress("simtime",&simtime);
-  configtree->SetBranchAddress("segtime",&segtime);
-  configtree->SetBranchAddress("seedtime",&seedtime);
-  configtree->SetBranchAddress("buildtime",&buildtime);
-  configtree->SetBranchAddress("fittime",&fittime);
-  configtree->SetBranchAddress("hlvtime",&hlvtime);
-  configtree->GetEntry(0);
-  
-  // fill histos
-  tottime->SetBinContent(1,simtime);
-  tottime->SetBinContent(2,segtime);
-  tottime->SetBinContent(3,seedtime);
-  tottime->SetBinContent(4,buildtime);
-  tottime->SetBinContent(5,fittime);
-  tottime->SetBinContent(6,hlvtime);
-  
-  rectime->SetBinContent(1,segtime);
-  rectime->SetBinContent(2,seedtime);
-  rectime->SetBinContent(3,buildtime);
-  rectime->SetBinContent(4,fittime);
-  
-  // normalize rec time
-  rectime->Scale(1.0/rectime->Integral());
-  
-  // draw and save stuff
-  PlotValidation::DrawWriteSaveTH1FPlot(subdir,tottime,subdirname,"total_time_sim",zeroSupLin);
-  PlotValidation::DrawWriteSaveTH1FPlot(subdir,rectime,subdirname,"norm_time_reco",zeroSupLin);
-
-  delete tottime;
-  delete rectime;
-  
-  delete configtree;
-}
-
-void PlotValidation::PlotSegment(){
-  // Get trees and set addresses
-  TTree * segtree = (TTree*)fInRoot->Get("segtree");
-  
-  UInt_t event  = 0;
-  UInt_t layer  = 0;
-  UInt_t etabin = 0;
-  UInt_t phibin = 0;
-  UInt_t nHits  = 0;
-  
-  segtree->SetBranchAddress("evtID",&event);
-  segtree->SetBranchAddress("layer",&layer);
-  segtree->SetBranchAddress("etabin",&etabin);
-  segtree->SetBranchAddress("phibin",&phibin);
-  segtree->SetBranchAddress("nHits",&nHits);
-  
-  // get config info
-  TTree * configtree = (TTree*)fInRoot->Get("configtree");
-  UInt_t nEvents  = 0;
-  UInt_t nLayers  = 0;
-  UInt_t nEtaPart = 0;
-  UInt_t nPhiPart = 0;
-  configtree->SetBranchAddress("Nevents",&nEvents);
-  configtree->SetBranchAddress("nLayers",&nLayers);
-  configtree->SetBranchAddress("nEtaPart",&nEtaPart);
-  configtree->SetBranchAddress("nPhiPart",&nPhiPart);
-  configtree->GetEntry(0);
-
-  ////////////////////////////////////////
-  // Store the info in relevant vectors //
-  ////////////////////////////////////////
-
-  // initialize the relevant vectors here
-  FltVecVec    nHitsEtaVV(nLayers); // vector to store how many hits in given eta bin (sum over the phi bins)
-  FltVecVecVec nHitsPhiVVV(nLayers); // vector to store how many hits in given eta-phi bin
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    nHitsEtaVV[ilay].resize(nEtaPart);
-    nHitsPhiVVV[ilay].resize(nEtaPart);
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      nHitsEtaVV[ilay][ieta] = 0;
-      nHitsPhiVVV[ilay][ieta].resize(nPhiPart);
-      for (UInt_t iphi = 0; iphi < nPhiPart; iphi++){
-	nHitsPhiVVV[ilay][ieta][iphi] = 0;
-      }
-    }
-  }
-
-  // just fill the eta-phi bin vector, and then sum over phi bins for the eta vector
-  for (UInt_t i = 0; i < segtree->GetEntries(); i++) {
-    segtree->GetEntry(i);
-    nHitsPhiVVV[layer][etabin][phibin] += nHits;     
-  }
-
-  // sum over phi bins into eta bin vector
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      for (UInt_t iphi = 0; iphi < nPhiPart; iphi++){
-	nHitsEtaVV[ilay][ieta] += nHitsPhiVVV[ilay][ieta][iphi];
-      }
-    }
-  }
-  
-  // average over events
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      nHitsEtaVV[ilay][ieta] /= nEvents;
-      for (UInt_t iphi = 0; iphi < nPhiPart; iphi++){
-	nHitsPhiVVV[ilay][ieta][iphi] /= nEvents;
-      }
-    }
-  }
-
-  // initialize plot vectors
-  TH1FRefVec    nHitsplots(nLayers);
-  TH1FRefVec    etabinplots(nLayers);
-  TH1FRefVecVec phibinplots(nLayers);
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    phibinplots[ilay].resize(nEtaPart);
-  }
-
-  // make output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "segment"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  // new and fill!
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    nHitsplots[ilay] = new TH1F(Form("h_nHits_perEtaPhiBin_lay%u",ilay),Form("nHits per EtaPhiBin (Layer: %u)",ilay),20,0,20);
-    nHitsplots[ilay]->GetXaxis()->SetTitle("nHits per EtaPhiBin");
-    nHitsplots[ilay]->GetYaxis()->SetTitle("nEtaPhiBins");
-    
-    etabinplots[ilay] = new TH1F(Form("h_nHits_vs_etabin_lay%u",ilay),Form("nHits vs EtaBin (Layer: %u)",ilay),nEtaPart,0,nEtaPart);
-    etabinplots[ilay]->GetXaxis()->SetTitle("Eta Bin Number");
-    etabinplots[ilay]->GetYaxis()->SetTitle("nHits in Eta Bin");
-
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      //fill the eta bin plots
-      etabinplots[ilay]->SetBinContent(ieta+1,nHitsEtaVV[ilay][ieta]);
-
-      // eta-phi bin plots new
-      phibinplots[ilay][ieta] = new TH1F(Form("h_nHits_vs_phibin_lay%u_eta%u",ilay,ieta),Form("nHits vs PhiBin (Layer: %u, EtaBin: %u)",ilay,ieta),nPhiPart,0,nPhiPart);
-      phibinplots[ilay][ieta]->GetXaxis()->SetTitle("Phi Bin Number");
-      phibinplots[ilay][ieta]->GetYaxis()->SetTitle("nHits in Phi Bin");
-
-      // fill eta-phi bin plots
-      for (UInt_t iphi = 0; iphi < nPhiPart; iphi++){
-	phibinplots[ilay][ieta]->SetBinContent(iphi+1,nHitsPhiVVV[ilay][ieta][iphi]);
-	nHitsplots[ilay]->Fill(nHitsPhiVVV[ilay][ieta][iphi]);
-      }
-    }
-  }
-
-  // write out the individual plots to the root file
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    PlotValidation::WriteTH1FPlot(subdir,nHitsplots[ilay]);
-    PlotValidation::WriteTH1FPlot(subdir,etabinplots[ilay]);
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      PlotValidation::WriteTH1FPlot(subdir,phibinplots[ilay][ieta]);
-    }
-  }
-
-  ///////////////////////////////
-  // Plot segment results here //
-  ///////////////////////////////
-
-  // first do the nHits plot
-  fTH1Canv->cd();
-  fTH1Canv->SetLogy(0);
-
-  Float_t max = 0;
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    Float_t tmpmax = nHitsplots[ilay]->GetBinContent(nHitsplots[ilay]->GetMaximumBin());
-    if (tmpmax > max) {
-      max = tmpmax;
-    }
-  }
-  
-  // overplot
-  TLegend * legnhit = new TLegend(0.75,0.7,0.9,0.9);
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    nHitsplots[ilay]->SetStats(0);
-    nHitsplots[ilay]->SetTitle("Average nHits per Event per EtaPhiBin for All Layers"); 
-    nHitsplots[ilay]->SetMaximum(1.1*max);
-    nHitsplots[ilay]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
-    nHitsplots[ilay]->SetLineWidth(2);
-    nHitsplots[ilay]->Draw((ilay>0)?"SAME":"");
-    legnhit->AddEntry(nHitsplots[ilay],Form("Layer %u",ilay),"L");
-  }
-  legnhit->Draw("SAME");
-  fTH1Canv->SaveAs(Form("%s/%s/nHits_perEtaPhiBin_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
-    delete nHitsplots[ilay];
-  }
-  delete legnhit;
-
-  // now we want to overplot the eta plots second
-  max = 0;
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    Float_t tmpmax = etabinplots[ilay]->GetBinContent(etabinplots[ilay]->GetMaximumBin());
-    if (tmpmax > max) {
-      max = tmpmax;
-    }
-  }
-  
-  // overplot
-  TLegend * legeta = new TLegend(0.75,0.7,0.9,0.9);
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    etabinplots[ilay]->SetStats(0);
-    etabinplots[ilay]->SetTitle("Average nHits per Event vs EtaBin for All Layers"); 
-    etabinplots[ilay]->SetMaximum(1.1*max);
-    etabinplots[ilay]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
-    etabinplots[ilay]->SetLineWidth(2);
-    etabinplots[ilay]->Draw((ilay>0)?"SAME":"");
-    legeta->AddEntry(etabinplots[ilay],Form("Layer %u",ilay),"L");
-  }
-  legeta->Draw("SAME");
-  fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Etabin_allLayers.%s",fOutName.Data(),subdirname.Data(),fOutType.Data()));    
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){ // delete all histos, including layers not filled in
-    delete etabinplots[ilay];
-  }
-  delete legeta;
-
-  // now we want to overplot the phi plots second ... a bit more complicated
-  // first do the phi bin plots for a given eta bin, overplot layer
-  // then  do the phi bin plots for a given layer, overplot eta bin
-
-  // so fix the eta bin, then overplot layers
-  for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-    Float_t max = 0;
-    for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-      Float_t tmpmax = phibinplots[ilay][ieta]->GetBinContent(phibinplots[ilay][ieta]->GetMaximumBin());
-      if (tmpmax > max) {
-	max = tmpmax;
-      }
-    }
-  
-    // overplot
-    TLegend * legphi = new TLegend(0.75,0.7,0.9,0.9);
-    for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-      phibinplots[ilay][ieta]->SetStats(0);
-      phibinplots[ilay][ieta]->SetTitle(Form("Average nHits per Event vs PhiBin for All Layers (EtaBin: %u)",ieta)); 
-      phibinplots[ilay][ieta]->SetMaximum(1.1*max);
-      phibinplots[ilay][ieta]->SetLineColor(fColors[ilay%fColorSize]+(ilay/fColorSize)); // allow colors to loop over base!
-      phibinplots[ilay][ieta]->SetLineWidth(2);
-      phibinplots[ilay][ieta]->Draw((ilay>0)?"SAME":"");
-      legphi->AddEntry(phibinplots[ilay][ieta],Form("Layer %u",ilay),"L");
-    }
-    legphi->Draw("SAME");
-    fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Phibin_allLayers_etabin%u.%s",fOutName.Data(),subdirname.Data(),ieta,fOutType.Data()));    
-    delete legphi;
-  }  
-  
-  // now fix layer, overplot eta bins
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    Float_t max = 0;
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      Float_t tmpmax = phibinplots[ilay][ieta]->GetBinContent(phibinplots[ilay][ieta]->GetMaximumBin());
-      if (tmpmax > max) {
-	max = tmpmax;
-      }
-    }
-  
-    // overplot
-    TLegend * legphi = new TLegend(0.75,0.7,0.9,0.9);
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      phibinplots[ilay][ieta]->SetStats(0);
-      phibinplots[ilay][ieta]->SetTitle(Form("Average nHits per Event vs PhiBin for All EtaBins (Layer: %u)",ilay)); 
-      phibinplots[ilay][ieta]->SetMaximum(1.1*max);
-      phibinplots[ilay][ieta]->SetLineColor(fColors[ieta%fColorSize]+(ieta/fColorSize)); // allow colors to loop over base!
-      phibinplots[ilay][ieta]->SetLineWidth(2);
-      phibinplots[ilay][ieta]->Draw((ieta>0)?"SAME":"");
-      legphi->AddEntry(phibinplots[ilay][ieta],Form("EtaBin %u",ieta),"L");
-    }
-    legphi->Draw("SAME");
-    fTH1Canv->SaveAs(Form("%s/%s/nHits_vs_Phibin_allEtaBins_layer%u.%s",fOutName.Data(),subdirname.Data(),ilay,fOutType.Data()));    
-    delete legphi;
-  }  
-  
-  for (UInt_t ilay = 0; ilay < nLayers; ilay++){
-    for (UInt_t ieta = 0; ieta < nEtaPart; ieta++){
-      delete phibinplots[ilay][ieta];
-    }
-  }
-
-  delete configtree;
-  delete segtree;
-}
-
 void PlotValidation::PlotSimGeo(){
   // Get tree
-  TTree * efftree = (TTree*)fInRoot->Get("efftree");
+  TTree * geotree = (TTree*)fInRoot->Get("geotree");
 
   // make output subdirectory and subdir in ROOT file, and cd to it.
   TString subdirname = "simgeo"; 
@@ -828,16 +1373,16 @@ void PlotValidation::PlotSimGeo(){
   Float_t yvrx = 0.;
   Float_t zvrx = 0.;
 
-  efftree->SetBranchAddress("x_mc_reco_hit",&xhit);
-  efftree->SetBranchAddress("y_mc_reco_hit",&yhit);
-  efftree->SetBranchAddress("z_mc_reco_hit",&zhit);
+  geotree->SetBranchAddress("x_mc_reco_hit",&xhit);
+  geotree->SetBranchAddress("y_mc_reco_hit",&yhit);
+  geotree->SetBranchAddress("z_mc_reco_hit",&zhit);
 
-  efftree->SetBranchAddress("x_mc_gen_vrx",&xvrx);
-  efftree->SetBranchAddress("y_mc_gen_vrx",&yvrx);
-  efftree->SetBranchAddress("z_mc_gen_vrx",&zvrx);
+  geotree->SetBranchAddress("x_mc_gen_vrx",&xvrx);
+  geotree->SetBranchAddress("y_mc_gen_vrx",&yvrx);
+  geotree->SetBranchAddress("z_mc_gen_vrx",&zvrx);
 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
+  for (Int_t k = 0; k < geotree->GetEntries(); k++){
+    geotree->GetEntry(k);
     for (UInt_t h = 0; h < xhit->size(); h++){ // x,y,z are all the same size
       Float_t radius = std::sqrt( ((*xhit)[h])*((*xhit)[h]) + ((*yhit)[h])*((*yhit)[h]) );
       xy_detplot->Fill((*xhit)[h],(*yhit)[h]);
@@ -865,15 +1410,23 @@ void PlotValidation::PlotSimGeo(){
   delete xy_vrxplot;
   delete rz_vrxplot;
 
-  delete efftree;
+  delete geotree;
 }
 
-void PlotValidation::PlotNHits(){
-  // Get tree --> can do this all with fake rate tree
-  TTree * fakeratetree = (TTree*)fInRoot->Get("fakeratetree");
+void PlotValidation::PlotPosResolutionPull(){
+  // get tree
+  TTree * geotree    = (TTree*)fInRoot->Get("geotree");
+  
+  // get nLayers
+  TTree * configtree = (TTree*)fInRoot->Get("configtree");
+  Int_t nlayers_per_seed = 0;
+  Int_t nLayers = 0;
+  configtree->SetBranchAddress("nlayers_per_seed",&nlayers_per_seed);
+  configtree->SetBranchAddress("nLayers",&nLayers);
+  configtree->GetEntry(0);
 
-  // make output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "nHits"; 
+  // make  output subdirectory and subdir in ROOT file, and cd to it.
+  TString subdirname = "position_resolutionpull"; 
   PlotValidation::MakeSubDirectory(subdirname);
   PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
   PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
@@ -881,109 +1434,132 @@ void PlotValidation::PlotNHits(){
   subdir->cd();
 
   //Declare strings for branches and plots
-  Bool_t  zeroSupLin = false;
-  TStrVec trks  = {"seed","build","fit"};
-  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
-  TStrVec coll  = {"allreco","fake","allmatch","bestmatch"};
-  TStrVec scoll = {"All Reco","Fake","All Match","Best Match"};
+  TStrVec vars      = {"x","y","z"};
+  TStrVec evars     = {"ex","ey","ez"};
+  TStrVec svars     = {"x","y","z"}; // svars --> labels for histograms for given variable
+  TStrVec sunits    = {" [cm]"," [cm]"," [cm]"}; // svars --> labels for histograms for given variable
+  IntVec nBinsRes  = {100,100,100};
+  FltVec  xlowRes   = {-0.5,-0.5,-0.5};
+  FltVec  xhighRes  = {0.5,0.5,0.5};  
+  FltVec  gausRes   = {0.3,0.3,0.3}; // symmetric bounds for gaussian fit
+  IntVec nBinsPull = {100,100,100};
+  FltVec  xlowPull  = {-5,-5,-5};
+  FltVec  xhighPull = {5,5,5};  
+  FltVec  gausPull  = {3,3,3}; // symmetric bounds for gaussian fit
 
-  // Floats/Ints to be filled for trees
-  IntVec nHits_trk(trks.size());
-  FltVec fracHitsMatched_trk(trks.size());
-  
-  // masks
-  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  IntVec seedmask_trk(trks.size()); // need to know if reco track associated to a seed track
-  IntVec iTkMatches_trk(trks.size()); 
-  
-  // Create plots
-  TH1FRefVecVec nHitsPlot(trks.size());
-  TH1FRefVecVec fracHitsMatchedPlot(trks.size());
+  TStrVec trks      = {"seed","fit"};
+  TStrVec strks     = {"Seed","Fit"}; // strk --> labels for histograms for given track type
+
+  IntVec nlayers_trk = {nlayers_per_seed, nLayers}; // want to resize just enough space
+
+  // Create pos plots
+  TH1FRefVecVecVec varsResPlot(trks.size()); // in this case, outer layer is tracks, then variable, then by layer
+  TH1FRefVecVecVec varsPullPlot(trks.size());
+
   for (UInt_t j = 0; j < trks.size(); j++){
-    nHitsPlot[j].resize(coll.size());
-    fracHitsMatchedPlot[j].resize(coll.size());
-  }
-
-  for (UInt_t j = 0; j < trks.size(); j++){
-    for (UInt_t c = 0; c < coll.size(); c++){
-      // Numerator only type plots only!
-      nHitsPlot[j][c] = new TH1F(Form("h_nHits_%s_%s",coll[c].Data(),trks[j].Data()),Form("%s %s Track vs nHits / Track",scoll[c].Data(),strks[j].Data()),11,0,11);
-      nHitsPlot[j][c]->GetXaxis()->SetTitle("nHits / Track");
-      nHitsPlot[j][c]->GetYaxis()->SetTitle("nTracks");    
-      nHitsPlot[j][c]->Sumw2();
-
-      fracHitsMatchedPlot[j][c] = new TH1F(Form("h_fracHitsMatched_%s_%s",coll[c].Data(),trks[j].Data()),Form("%s %s Track vs Highest Fraction of Matched Hits / Track",scoll[c].Data(),strks[j].Data()),4000,0,1.1);
-      fracHitsMatchedPlot[j][c]->GetXaxis()->SetTitle("Highest Fraction of Matched Hits / Track");
-      fracHitsMatchedPlot[j][c]->GetYaxis()->SetTitle("nTracks");    
-      fracHitsMatchedPlot[j][c]->Sumw2();
+    varsResPlot[j].resize(vars.size());
+    varsPullPlot[j].resize(vars.size());
+    for (UInt_t i = 0; i < vars.size(); i++){
+      varsResPlot[j][i].resize(nlayers_trk[j]);
+      varsPullPlot[j][i].resize(nlayers_trk[j]);
     }
   }
 
-  //Initialize masks and variables, set branch addresses  
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    mcmask_trk[j]          = 0;
-    seedmask_trk[j]        = 0;
-    iTkMatches_trk[j]      = 0;
-    nHits_trk[j]           = 0;
-    fracHitsMatched_trk[j] = 0;
+  for (UInt_t j = 0; j < trks.size(); j++){
+    for (UInt_t i = 0; i < vars.size(); i++){
+      for (Int_t l = 0; l < nlayers_trk[j]; l++){	
+	//Res
+	varsResPlot[j][i][l] = new TH1F(Form("h_%s_res_lay_%u_%s",vars[i].Data(),l,trks[j].Data()),Form("%s Resolution Layer %u (%s Track vs. MC Track)",svars[i].Data(),l,strks[j].Data()),nBinsRes[i],xlowRes[i],xhighRes[i]);
+	varsResPlot[j][i][l]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/%s^{mc}%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data()));
+	varsResPlot[j][i][l]->GetYaxis()->SetTitle("nTracks");
 
-    fakeratetree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
-    fakeratetree->SetBranchAddress(Form("seedmask_%s",trks[j].Data()),&(seedmask_trk[j]));
-    fakeratetree->SetBranchAddress(Form("iTkMatches_%s",trks[j].Data()),&(iTkMatches_trk[j]));
-    fakeratetree->SetBranchAddress(Form("nHits_%s",trks[j].Data()),&(nHits_trk[j]));
-    fakeratetree->SetBranchAddress(Form("fracHitsMatched_%s",trks[j].Data()),&(fracHitsMatched_trk[j]));
+	//Pull
+	varsPullPlot[j][i][l] = new TH1F(Form("h_%s_pull_lay_%u_%s",vars[i].Data(),l,trks[j].Data()),Form("%s Pull Layer %u (%s Track vs. MC Track)",svars[i].Data(),l,strks[j].Data()),nBinsPull[i],xlowPull[i],xhighPull[i]);
+	varsPullPlot[j][i][l]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/#sigma(%s^{%s})%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),strks[j].Data(),sunits[i].Data()));
+	varsPullPlot[j][i][l]->GetYaxis()->SetTitle("nTracks");
+      }
+    }
+  }
+
+  // Floats/Ints to be filled for trees
+  IntVecRefVec    layers_trk(trks.size());   // only needed per track type
+  FltVecRefVecVec recovars_val(trks.size()); // first index is nVars, second is nTrkTypes
+  FltVecRefVecVec recovars_err(trks.size());
+  for (UInt_t j = 0; j < trks.size(); j++){
+    layers_trk[j] = new IntVec(); // initialize pointer
+
+    recovars_val[j].resize(vars.size());
+    recovars_err[j].resize(vars.size());
+    for (UInt_t i = 0; i < vars.size(); i++){
+      recovars_val[j][i] = new FltVec(); // initialize pointers
+      recovars_err[j][i] = new FltVec(); // initialize pointers
+    }
+  }
+
+  IntVec       mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
+  FltVecRefVec mcvars_val(vars.size()); // good for all track types
+  for (UInt_t i = 0; i < vars.size(); i++){
+    mcvars_val[i] = 0; // initialize pointers
+  }
+  FltVec vars_out = {0.,0.}; // res/pull output initialization
+
+  //Initialize var_val/err arrays, SetBranchAddress
+  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
+    // get the layers needed for reco vars
+    geotree->SetBranchAddress(Form("layers_%s",trks[j].Data()),&layers_trk[j]); 
+    geotree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));   
+
+    for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
+      //Set var+trk branch
+      geotree->SetBranchAddress(Form("%s_lay_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[j][i]));
+      geotree->SetBranchAddress(Form("%s_lay_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[j][i]));
+    }
+  }
+
+  for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
+    geotree->SetBranchAddress(Form("%s_mc_reco_hit",vars[i].Data()),&(mcvars_val[i]));
   }
 
   // Fill histos, compute res/pull from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) fakeratetree->GetEntries(); k++){
-    fakeratetree->GetEntry(k);
+  for (Int_t k = 0; k < geotree->GetEntries(); k++){
+    geotree->GetEntry(k);
     for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-      for (UInt_t c = 0; c < coll.size(); c++){ // loop over trk collection type
-	if (c == 0) { // all reco
-	  if (seedmask_trk[j] == 1){
-	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
-	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
+      if (mcmask_trk[j] == 1){ // must be associated
+	for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
+	  for (UInt_t l = 0; l < layers_trk[j]->size(); l++){ // loop over layers, assuming one hit per layer
+	    const Int_t layer = (*layers_trk[j])[l]; // layer we are on.
+	    if (layer < 0) continue; 
+	    PlotValidation::ComputeResolutionPull((*mcvars_val[i])[layer],(*recovars_val[j][i])[l],(*recovars_err[j][i])[l],vars_out); // we assume one hit per layer and track is simulated to be built outward
+	    if (!isnan(vars_out[0])){ // fill if not nan
+	      varsResPlot[j][i][layer]->Fill(vars_out[0]);
+	    }
+	    if (!isnan(vars_out[1])){ // fill if not nan
+	      varsPullPlot[j][i][layer]->Fill(vars_out[1]);
+	    }
 	  }
-	}
-	else if (c == 1) { // fake 
-	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 0)) { 
-	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
-	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
-	  }
-	}
-	else if (c == 2) { // all matches  
-	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 1)) {
-	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
-	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
-	  }
-	}
-	else if (c == 3) { // best matches only	  
-	  if ((seedmask_trk[j] == 1) && (mcmask_trk[j] == 1) && (iTkMatches_trk[j] == 0)) {
-	    nHitsPlot[j][c]->Fill(nHits_trk[j]);
-	    fracHitsMatchedPlot[j][c]->Fill(fracHitsMatched_trk[j]);
-	  }
-	}
-      } // end loop over trk type collection
+	} // end loop over vars
+      } // must be a matched track to make resolution plots
     } // end loop over trks
   } // end loop over entry in tree
-  
-  // Draw and save nHits plots
+
+  // Draw, fit, and save plots
   for (UInt_t j = 0; j < trks.size(); j++){
-    for (UInt_t c = 0; c < coll.size(); c++){ // loop over trk collection type
-      PlotValidation::DrawWriteSaveTH1FPlot(subdir,nHitsPlot[j][c],subdirname,Form("nHits_%s_%s",coll[c].Data(),trks[j].Data()),zeroSupLin);
-      PlotValidation::DrawWriteSaveTH1FPlot(subdir,fracHitsMatchedPlot[j][c],subdirname,Form("fracHitsMatched_%s_%s",coll[c].Data(),trks[j].Data()),zeroSupLin);
-      
-      delete nHitsPlot[j][c];
-      delete fracHitsMatchedPlot[j][c];
+    for (UInt_t i = 0; i < vars.size(); i++){
+      for (Int_t l = 0; l < nlayers_trk[j]; l++){
+	PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsResPlot[j][i][l],subdirname,Form("%s_resolution_lay%u_%s",vars[i].Data(),l,trks[j].Data()),gausRes[i]);
+	PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsPullPlot[j][i][l],subdirname,Form("%s_pull_lay%u_%s",vars[i].Data(),l,trks[j].Data()),gausPull[i]);
+	delete varsResPlot[j][i][l];
+	delete varsPullPlot[j][i][l];
+      }
     }
   }  
-    
-  delete fakeratetree;
+  delete configtree;
+  delete geotree;
 }
 
 void PlotValidation::PlotCFResidual(){
   // Get tree
-  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
+  TTree * cftree  = (TTree*)fInRoot->Get("cftree");
 
   // make output subdirectory and subdir in ROOT file, and cd to it.
   TString subdirname = "conformalFit_residual"; 
@@ -998,7 +1574,7 @@ void PlotValidation::PlotCFResidual(){
   TStrVec vars    = {"x","y","z","px","py","pz","pt","invpt","phi","theta"}; // pt will be inverse
   TStrVec svars   = {"x","y","z","p_{x}","p_{y}","p_{z}","p_{T}","1/p_{T}","#phi","#theta"}; // svars --> labels for histograms for given variable
   TStrVec sunits  = {" [cm]"," [cm]"," [cm]"," [GeV/c]"," [GeV/c]"," [GeV/c]"," [GeV/c]"," [GeV/c]^{-1}","",""}; // svars --> labels for histograms for given variable
-  UIntVec nBins   = {100,100,100,100,100,100,100,100,100,100};
+  IntVec nBins   = {100,100,100,100,100,100,100,100,100,100};
   FltVec  xlow    = {-0.05,-0.05,-0.5,-0.5,-0.5,-0.5,-0.5,-0.05,-0.05,-0.05};
   FltVec  xhigh   = {0.05,0.05,0.5,0.5,0.5,0.5,0.5,0.05,0.05,0.05};  
   FltVec  gaus    = {0.03,0.03,0.3,0.3,0.3,0.3,0.3,0.03,0.03,0.03}; // symmetric bounds for gaussian fit
@@ -1037,20 +1613,20 @@ void PlotValidation::PlotCFResidual(){
       recovars_val[i][j] = 0.;
       
       //Set var+trk branch
-      efftree->SetBranchAddress(Form("%s_mc_cf_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
-      efftree->SetBranchAddress(Form("%s_cf_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
+      cftree->SetBranchAddress(Form("%s_mc_cf_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
+      cftree->SetBranchAddress(Form("%s_cf_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
     }
   }
   
   //Initialize masks, set branch addresses  
   for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
     mcmask_trk[j] = 0;
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+    cftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
   }
 
   // Fill histos, compute residual from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
+  for (Int_t k = 0; k < cftree->GetEntries(); k++){
+    cftree->GetEntry(k);
     for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
       for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
 	if (mcmask_trk[j] == 1){ // must be associated
@@ -1070,12 +1646,12 @@ void PlotValidation::PlotCFResidual(){
       delete varsResidualPlot[i][j];
     }
   }  
-  delete efftree;
+  delete cftree;
 }
 
 void PlotValidation::PlotCFResolutionPull(){
   // Get tree
-  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
+  TTree * cftree  = (TTree*)fInRoot->Get("cftree");
 
   // make output subdirectory and subdir in ROOT file, and cd to it.
   TString subdirname = "conformalFit_resolutionpull"; 
@@ -1093,11 +1669,11 @@ void PlotValidation::PlotCFResolutionPull(){
   TStrVec evars     = {"ex","ey","ez","epx","epy","epz","ept","einvpt","ephi","etheta"};
   TStrVec trks      = {"seed","fit"};
   TStrVec strks     = {"Seed","Fit"}; // strk --> labels for histograms for given track type
-  UIntVec nBinsRes  = {100,100,100,100,100,100,100,100,100,100};
+  IntVec nBinsRes  = {100,100,100,100,100,100,100,100,100,100};
   FltVec  xlowRes   = {-0.05,-0.05,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5,-0.5};
   FltVec  xhighRes  = {0.05,0.05,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5};  
   FltVec  gausRes   = {0.03,0.03,0.3,0.3,0.3,0.3,0.3,0.3,0.3,0.3}; // symmetric bounds for gaussian fit
-  UIntVec nBinsPull = {100,100,100,100,100,100,100,100,100,100};
+  IntVec nBinsPull = {100,100,100,100,100,100,100,100,100,100};
   FltVec  xlowPull  = {-5,-5,-5,-5,-5,-5,-5,-5,-5,-5};
   FltVec  xhighPull = {5,5,5,5,5,5,5,5,5,5};  
   FltVec  gausPull  = {3,3,3,3,3,3,3,3,3,3}; // symmetric bounds for gaussian fit
@@ -1145,21 +1721,21 @@ void PlotValidation::PlotCFResolutionPull(){
       recovars_err[i][j] = 0.;
       
       //Set var+trk branch
-      efftree->SetBranchAddress(Form("%s_mc_cf_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
-      efftree->SetBranchAddress(Form("%s_cf_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
-      efftree->SetBranchAddress(Form("%s_cf_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[i][j]));
+      cftree->SetBranchAddress(Form("%s_mc_cf_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
+      cftree->SetBranchAddress(Form("%s_cf_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
+      cftree->SetBranchAddress(Form("%s_cf_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[i][j]));
     }
   }
   
   //Initialize masks, set branch addresses  
   for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
     mcmask_trk[j] = 0;
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
+    cftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
   }
 
   // Fill histos, compute res/pull from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
+  for (Int_t k = 0; k < cftree->GetEntries(); k++){
+    cftree->GetEntry(k);
     for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
       for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
 	if (mcmask_trk[j] == 1){ // must be associated
@@ -1184,578 +1760,7 @@ void PlotValidation::PlotCFResolutionPull(){
       delete varsPullPlot[i][j];
     }
   }  
-  delete efftree;
-}
-
-void PlotValidation::PlotPosResolutionPull(){
-  // get tree
-  TTree * efftree    = (TTree*)fInRoot->Get("efftree");
-  
-  // get nLayers
-  TTree * configtree = (TTree*)fInRoot->Get("configtree");
-  UInt_t nlayers_per_seed = 0;
-  UInt_t nLayers = 0;
-  configtree->SetBranchAddress("nlayers_per_seed",&nlayers_per_seed);
-  configtree->SetBranchAddress("nLayers",&nLayers);
-  configtree->GetEntry(0);
-
-  // make  output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "position_resolutionpull"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  //Declare strings for branches and plots
-  TStrVec vars      = {"x","y","z"};
-  TStrVec evars     = {"ex","ey","ez"};
-  TStrVec svars     = {"x","y","z"}; // svars --> labels for histograms for given variable
-  TStrVec sunits    = {" [cm]"," [cm]"," [cm]"}; // svars --> labels for histograms for given variable
-  UIntVec nBinsRes  = {100,100,100};
-  FltVec  xlowRes   = {-0.5,-0.5,-0.5};
-  FltVec  xhighRes  = {0.5,0.5,0.5};  
-  FltVec  gausRes   = {0.3,0.3,0.3}; // symmetric bounds for gaussian fit
-  UIntVec nBinsPull = {100,100,100};
-  FltVec  xlowPull  = {-5,-5,-5};
-  FltVec  xhighPull = {5,5,5};  
-  FltVec  gausPull  = {3,3,3}; // symmetric bounds for gaussian fit
-
-  TStrVec trks      = {"seed","fit"};
-  TStrVec strks     = {"Seed","Fit"}; // strk --> labels for histograms for given track type
-
-  UIntVec nlayers_trk = {nlayers_per_seed, nLayers}; // want to resize just enough space
-
-  // Create pos plots
-  TH1FRefVecVecVec varsResPlot(trks.size()); // in this case, outer layer is tracks, then variable, then by layer
-  TH1FRefVecVecVec varsPullPlot(trks.size());
-
-  for (UInt_t j = 0; j < trks.size(); j++){
-    varsResPlot[j].resize(vars.size());
-    varsPullPlot[j].resize(vars.size());
-    for (UInt_t i = 0; i < vars.size(); i++){
-      varsResPlot[j][i].resize(nlayers_trk[j]);
-      varsPullPlot[j][i].resize(nlayers_trk[j]);
-    }
-  }
-
-  for (UInt_t j = 0; j < trks.size(); j++){
-    for (UInt_t i = 0; i < vars.size(); i++){
-      for (UInt_t l = 0; l < nlayers_trk[j]; l++){	
-	//Res
-	varsResPlot[j][i][l] = new TH1F(Form("h_%s_res_lay_%u_%s",vars[i].Data(),l,trks[j].Data()),Form("%s Resolution Layer %u (%s Track vs. MC Track)",svars[i].Data(),l,strks[j].Data()),nBinsRes[i],xlowRes[i],xhighRes[i]);
-	varsResPlot[j][i][l]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/%s^{mc}%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data()));
-	varsResPlot[j][i][l]->GetYaxis()->SetTitle("nTracks");
-
-	//Pull
-	varsPullPlot[j][i][l] = new TH1F(Form("h_%s_pull_lay_%u_%s",vars[i].Data(),l,trks[j].Data()),Form("%s Pull Layer %u (%s Track vs. MC Track)",svars[i].Data(),l,strks[j].Data()),nBinsPull[i],xlowPull[i],xhighPull[i]);
-	varsPullPlot[j][i][l]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/#sigma(%s^{%s})%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),strks[j].Data(),sunits[i].Data()));
-	varsPullPlot[j][i][l]->GetYaxis()->SetTitle("nTracks");
-      }
-    }
-  }
-
-  // Floats/Ints to be filled for trees
-  UIntVecRefVec   layers_trk(trks.size());   // only needed per track type
-  FltVecRefVecVec recovars_val(trks.size()); // first index is nVars, second is nTrkTypes
-  FltVecRefVecVec recovars_err(trks.size());
-  for (UInt_t j = 0; j < trks.size(); j++){
-    layers_trk[j] = new UIntVec(); // initialize pointer
-
-    recovars_val[j].resize(vars.size());
-    recovars_err[j].resize(vars.size());
-    for (UInt_t i = 0; i < vars.size(); i++){
-      recovars_val[j][i] = new FltVec(); // initialize pointers
-      recovars_err[j][i] = new FltVec(); // initialize pointers
-    }
-  }
-
-  IntVec       mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  FltVecRefVec mcvars_val(vars.size()); // good for all track types
-  for (UInt_t i = 0; i < vars.size(); i++){
-    mcvars_val[i] = 0; // initialize pointers
-  }
-  FltVec vars_out = {0.,0.}; // res/pull output initialization
-
-  //Initialize var_val/err arrays, SetBranchAddress
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    // get the layers needed for reco vars
-    efftree->SetBranchAddress(Form("layers_%s",trks[j].Data()),&layers_trk[j]); 
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));   
-
-    for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
-      //Set var+trk branch
-      efftree->SetBranchAddress(Form("%s_lay_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[j][i]));
-      efftree->SetBranchAddress(Form("%s_lay_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[j][i]));
-    }
-  }
-
-  for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
-    efftree->SetBranchAddress(Form("%s_mc_reco_hit",vars[i].Data()),&(mcvars_val[i]));
-  }
-
-  // Fill histos, compute res/pull from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
-    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-      if (mcmask_trk[j] == 1){ // must be associated
-	for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
-	  for (UInt_t l = 0; l < layers_trk[j]->size(); l++){ // loop over layers, assuming one hit per layer
-	    const UInt_t layer = (*layers_trk[j])[l]; // layer we are on.
-	    PlotValidation::ComputeResolutionPull((*mcvars_val[i])[layer],(*recovars_val[j][i])[l],(*recovars_err[j][i])[l],vars_out); // we assume one hit per layer and track is simulated to be built outward
-	    if (!isnan(vars_out[0])){ // fill if not nan
-	      varsResPlot[j][i][layer]->Fill(vars_out[0]);
-	    }
-	    if (!isnan(vars_out[1])){ // fill if not nan
-	      varsPullPlot[j][i][layer]->Fill(vars_out[1]);
-	    }
-	  }
-	} // end loop over vars
-      } // must be a matched track to make resolution plots
-    } // end loop over trks
-  } // end loop over entry in tree
-
-  // Draw, fit, and save plots
-  for (UInt_t j = 0; j < trks.size(); j++){
-    for (UInt_t i = 0; i < vars.size(); i++){
-      for (UInt_t l = 0; l < nlayers_trk[j]; l++){
-	PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsResPlot[j][i][l],subdirname,Form("%s_resolution_lay%u_%s",vars[i].Data(),l,trks[j].Data()),gausRes[i]);
-	PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsPullPlot[j][i][l],subdirname,Form("%s_pull_lay%u_%s",vars[i].Data(),l,trks[j].Data()),gausPull[i]);
-	delete varsResPlot[j][i][l];
-	delete varsPullPlot[j][i][l];
-      }
-    }
-  }  
-  delete configtree;
-  delete efftree;
-}
-
-void PlotValidation::PlotMomResolutionPull(){
-  // Get tree
-  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
-
-  // make  output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "momentum_resolutionpull"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  //Declare strings for branches and plots
-  TStrVec vars      = {"pt","eta","phi"};
-  TStrVec evars     = {"ept","eeta","ephi"};
-  TStrVec svars     = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
-  TStrVec sunits    = {" [GeV/c]","",""}; // units --> labels for histograms for given variable
-  UIntVec nBinsRes  = {100,100,100};
-  FltVec  xlowRes   = {-0.5,-0.5,-0.5};
-  FltVec  xhighRes  = {0.5,0.5,0.5};  
-  FltVec  gausRes   = {0.3,0.3,0.3}; // symmetric bounds for gaussian fit
-  UIntVec nBinsPull = {100,100,100};
-  FltVec  xlowPull  = {-5,-5,-5};
-  FltVec  xhighPull = {5,5,5};  
-  FltVec  gausPull  = {3,3,3}; // symmetric bounds for gaussian fit
-
-  TStrVec trks      = {"seed","build","fit"};
-  TStrVec strks     = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
-
-  // Floats/Ints to be filled for trees
-  FltVecVec mcvars_val(vars.size());
-  IntVec    mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  FltVecVec recovars_val(vars.size()); // first index is nVars, second is nTrkTypes
-  FltVecVec recovars_err(vars.size());
-  for (UInt_t i = 0; i < vars.size(); i++){
-    mcvars_val[i].resize(trks.size());
-    recovars_val[i].resize(trks.size());
-    recovars_err[i].resize(trks.size());
-  }
-  FltVec vars_out = {0.,0.}; // res/pull output
-  
-  // Create pos plots
-  TH1FRefVecVec varsResPlot(vars.size());
-  TH1FRefVecVec varsPullPlot(vars.size());
-  for (UInt_t i = 0; i < vars.size(); i++){
-    varsResPlot[i].resize(trks.size());
-    varsPullPlot[i].resize(trks.size());
-  }
-
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      //Res
-      varsResPlot[i][j] = new TH1F(Form("h_%s_res_%s",vars[i].Data(),trks[j].Data()),Form("%s Resolution (%s Track vs. MC Track)",svars[i].Data(),strks[j].Data()),nBinsRes[i],xlowRes[i],xhighRes[i]);
-      varsResPlot[i][j]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/%s^{mc}%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data()));
-      varsResPlot[i][j]->GetYaxis()->SetTitle("nTracks");
-      varsResPlot[i][j]->Sumw2();
-
-      //Pull
-      varsPullPlot[i][j] = new TH1F(Form("h_%s_pull_%s",vars[i].Data(),trks[j].Data()),Form("%s Pull (%s Track vs. MC Track)",svars[i].Data(),strks[j].Data()),nBinsPull[i],xlowPull[i],xhighPull[i]);
-      varsPullPlot[i][j]->GetXaxis()->SetTitle(Form("(%s^{%s}%s - %s^{mc}%s)/#sigma(%s^{%s})%s",svars[i].Data(),strks[j].Data(),sunits[i].Data(),svars[i].Data(),sunits[i].Data(),svars[i].Data(),strks[j].Data(),sunits[i].Data()));
-      varsPullPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      varsPullPlot[i][j]->Sumw2();
-    }
-  }
-
-  //Initialize var_val/err arrays, SetBranchAddress
-  for (UInt_t i = 0; i < vars.size(); i++){ // loop over var index
-    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-      // initialize var + errors
-      mcvars_val[i][j] = 0.;
-      recovars_val[i][j] = 0.;
-      recovars_err[i][j] = 0.;
-      
-      //Set var+trk branch
-      efftree->SetBranchAddress(Form("%s_mc_%s",vars[i].Data(),trks[j].Data()),&(mcvars_val[i][j]));
-      efftree->SetBranchAddress(Form("%s_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
-      efftree->SetBranchAddress(Form("%s_%s",evars[i].Data(),trks[j].Data()),&(recovars_err[i][j]));
-    }
-  }
-  
-  //Initialize masks, set branch addresses  
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    mcmask_trk[j] = 0;
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
-  }
-
-  // Fill histos, compute res/pull from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
-    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
-      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-	if (mcmask_trk[j] == 1){ // must be associated
-	  PlotValidation::ComputeResolutionPull(mcvars_val[i][j],recovars_val[i][j],recovars_err[i][j],vars_out);
-	  if (!isnan(vars_out[0])){ // fill if not nan
-	    varsResPlot[i][j]->Fill(vars_out[0]);
-	  }
-	  if (!isnan(vars_out[1])){ // fill if not nan
-	    varsPullPlot[i][j]->Fill(vars_out[1]);
-	  }
-	} // must be a matched track to make resolution plots
-      } // end loop over trks
-    } // end loop over vars
-  } // end loop over entry in tree
-
-  // Draw, fit, and save plots
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsResPlot[i][j],subdirname,Form("%s_resolution_%s",vars[i].Data(),trks[j].Data()),gausRes[i]);
-      PlotValidation::DrawWriteFitSaveTH1FPlot(subdir,varsPullPlot[i][j],subdirname,Form("%s_pull_%s",vars[i].Data(),trks[j].Data()),gausPull[i]);
-      delete varsResPlot[i][j];
-      delete varsPullPlot[i][j];
-    }
-  }  
-  delete efftree;
-}
-
-void PlotValidation::PlotEfficiency(){
-  // Get tree
-  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
-
-  // make output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "efficiency"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  //Declare strings for branches and plots
-  Bool_t  zeroSupLin = true;
-  TStrVec vars  = {"pt","eta","phi"};
-  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
-  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
-  UIntVec nBins = {60,60,80};
-  FltVec  xlow  = {0,-3,-4};
-  FltVec  xhigh = {15,3,4};  
-
-  TStrVec trks  = {"seed","build","fit"};
-  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
-
-  // Floats/Ints to be filled for trees
-  FltVec mcvars_val(vars.size()); // first index is var. only for mc values! so no extra index 
-  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  
-  // Create plots
-  TH1FRefVecVec varsNumerPlot(vars.size());
-  TH1FRefVecVec varsDenomPlot(vars.size());
-  TH1FRefVecVec varsEffPlot(vars.size());
-  for (UInt_t i = 0; i < vars.size(); i++){
-    varsNumerPlot[i].resize(trks.size());
-    varsDenomPlot[i].resize(trks.size());
-    varsEffPlot[i].resize(trks.size());
-  }  
-
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      // Numerator
-      varsNumerPlot[i][j] = new TH1F(Form("h_sim_%s_numer_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Numer) Eff",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Denominator
-      varsDenomPlot[i][j] = new TH1F(Form("h_sim_%s_denom_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Denom) Eff",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Effiency
-      varsEffPlot[i][j] = new TH1F(Form("h_sim_%s_eff_%s_eff",vars[i].Data(),trks[j].Data()),Form("%s Track Effiency vs MC %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsEffPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsEffPlot[i][j]->GetYaxis()->SetTitle("Efficiency");    
-    }
-  }
-
-  //Initialize var_val/err arrays, SetBranchAddress
-  for (UInt_t i = 0; i < vars.size(); i++){ // loop over trks index
-    // initialize var
-    mcvars_val[i] = 0.;
-    
-    //Set var+trk branch
-    efftree->SetBranchAddress(Form("%s_mc_gen",vars[i].Data()),&(mcvars_val[i]));
-  }
-  
-  //Initialize masks, set branch addresses  
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    mcmask_trk[j] = 0;
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
-  }
-
-  // Fill histos, compute eff from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
-    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
-      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-	varsDenomPlot[i][j]->Fill(mcvars_val[i]);
-	if (mcmask_trk[j] == 1){ // must be associated
-	  varsNumerPlot[i][j]->Fill(mcvars_val[i]);
-	} // must be a matched track for effiency
-      } // end loop over trks
-    } // end loop over vars
-  } // end loop over entry in tree
-
-  // Draw, divide, and save efficiency plots
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsEffPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
-      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsEffPlot[i][j],subdirname,Form("%s_eff_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
-      delete varsNumerPlot[i][j];
-      delete varsDenomPlot[i][j];
-      delete varsEffPlot[i][j];
-    }
-  }  
-  delete efftree;
-}
-
-void PlotValidation::PlotFakeRate(){
-  // Get tree
-  TTree * fakeratetree  = (TTree*)fInRoot->Get("fakeratetree");
-
-  // make output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "fakerate"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  //Declare strings for branches and plots
-  Bool_t  zeroSupLin = true;
-  TStrVec vars  = {"pt","eta","phi"};
-  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
-  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
-  UIntVec nBins = {60,60,80};
-  FltVec  xlow  = {0,-3,-4};
-  FltVec  xhigh = {15,3,4};  
-
-  TStrVec trks  = {"seed","build","fit"};
-  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
-
-  // Floats/Ints to be filled for trees
-  FltVecVec recovars_val(vars.size()); // first index is var, second is type of track
-  for (UInt_t i = 0; i < vars.size(); i++){
-    recovars_val[i].resize(trks.size());
-  }
-
-  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  IntVec seedmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  
-  // Create FR plots
-  TH1FRefVecVec varsNumerPlot(vars.size());
-  TH1FRefVecVec varsDenomPlot(vars.size());
-  TH1FRefVecVec varsFRPlot(vars.size());
-  for (UInt_t i = 0; i < vars.size(); i++){
-    varsNumerPlot[i].resize(trks.size());
-    varsDenomPlot[i].resize(trks.size());
-    varsFRPlot[i].resize(trks.size());
-  }  
-
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      // Numerator
-      varsNumerPlot[i][j] = new TH1F(Form("h_reco_%s_numer_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track vs Reco %s (Numer) FR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Denominator
-      varsDenomPlot[i][j] = new TH1F(Form("h_reco_%s_denom_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track vs Reco %s (Denom) FR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Fake Rate
-      varsFRPlot[i][j] = new TH1F(Form("h_reco_%s_FR_%s_FR",vars[i].Data(),trks[j].Data()),Form("%s Track Fake Rate vs Reco %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsFRPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsFRPlot[i][j]->GetYaxis()->SetTitle("Fake Rate");    
-    }
-  }
-
-  //Initialize var_val/err arrays, SetBranchAddress
-  for (UInt_t i = 0; i < vars.size(); i++){ // loop over vars index
-    for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-      // initialize var
-      recovars_val[i][j] = 0.;
-    
-      //Set var+trk branch
-      fakeratetree->SetBranchAddress(Form("%s_%s",vars[i].Data(),trks[j].Data()),&(recovars_val[i][j]));
-    }
-  }
-  
-  //Initialize masks, set branch addresses  
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    mcmask_trk[j] = 0;
-    seedmask_trk[j] = 0;
-    
-    fakeratetree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
-    fakeratetree->SetBranchAddress(Form("seedmask_%s",trks[j].Data()),&(seedmask_trk[j]));
-  }
-
-  // Fill histos, compute fake rate from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) fakeratetree->GetEntries(); k++){
-    fakeratetree->GetEntry(k);
-    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
-      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-	if (seedmask_trk[j] == 1) { // make sure it is actually a reco track matched to a seed
-	  varsDenomPlot[i][j]->Fill(recovars_val[i][j]); // all reco tracks fill denom
-	  if (mcmask_trk[j] == 0){ // only completely unassociated reco tracks enter FR
-	    varsNumerPlot[i][j]->Fill(recovars_val[i][j]);
-	  } // must be an unmatched track for FR
-	} // must be a real reco track for FR
-      } // end loop over trks
-    } // end loop over vars
-  } // end loop over entry in tree
-
-  // Draw, divide, and save fake rate plots --> then delete!
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsFRPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
-      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsFRPlot[i][j],subdirname,Form("%s_FR_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
-      delete varsNumerPlot[i][j];
-      delete varsDenomPlot[i][j];
-      delete varsFRPlot[i][j];
-    }
-  }  
-  delete fakeratetree;
-}
-
-void PlotValidation::PlotDuplicateRate(){
-  // Get tree
-  TTree * efftree  = (TTree*)fInRoot->Get("efftree");
-
-  // make output subdirectory and subdir in ROOT file, and cd to it.
-  TString subdirname = "duplicaterate"; 
-  PlotValidation::MakeSubDirectory(subdirname);
-  PlotValidation::MakeSubDirectory(Form("%s/lin",subdirname.Data()));
-  PlotValidation::MakeSubDirectory(Form("%s/log",subdirname.Data()));
-  TDirectory * subdir = fOutRoot->mkdir(subdirname.Data());
-  subdir->cd();
-
-  //Declare strings for branches and plots
-  Bool_t  zeroSupLin = true;
-  TStrVec vars  = {"pt","eta","phi"};
-  TStrVec svars = {"p_{T}","#eta","#phi"}; // svars --> labels for histograms for given variable
-  TStrVec sunits= {" [GeV/c]","",""}; // units --> labels for histograms for given variable
-  UIntVec nBins = {60,60,80};
-  FltVec  xlow  = {0,-3,-4};
-  FltVec  xhigh = {15,3,4};  
-
-  TStrVec trks  = {"seed","build","fit"};
-  TStrVec strks = {"Seed","Build","Fit"}; // strk --> labels for histograms for given track type
-
-  // Floats/Ints to be filled for trees
-  FltVec mcvars_val(vars.size()); // first index is var. only for mc values! so no extra index 
-  IntVec mcmask_trk(trks.size()); // need to know if sim track associated to a given reco track type
-  IntVec nTkMatches_trk(trks.size()); // need to know how many duplicates each mc track produces.  nDupl == 1 means one reco track
-  
-  // Create DR plots
-  TH1FRefVecVec varsNumerPlot(vars.size());
-  TH1FRefVecVec varsDenomPlot(vars.size());
-  TH1FRefVecVec varsDRPlot(vars.size());
-  for (UInt_t i = 0; i < vars.size(); i++){
-    varsNumerPlot[i].resize(trks.size());
-    varsDenomPlot[i].resize(trks.size());
-    varsDRPlot[i].resize(trks.size());
-  }  
-
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      // Numerator
-      varsNumerPlot[i][j] = new TH1F(Form("h_sim_%s_numer_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Numer) DR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsNumerPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsNumerPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Denominator
-      varsDenomPlot[i][j] = new TH1F(Form("h_sim_%s_denom_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track vs MC %s (Denom) DR",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsDenomPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsDenomPlot[i][j]->GetYaxis()->SetTitle("nTracks");    
-      // Duplicate Rate
-      varsDRPlot[i][j] = new TH1F(Form("h_sim_%s_DR_%s_DR",vars[i].Data(),trks[j].Data()),Form("%s Track Duplicate Rate vs MC %s",strks[j].Data(),svars[i].Data()),nBins[i],xlow[i],xhigh[i]);
-      varsDRPlot[i][j]->GetXaxis()->SetTitle(Form("%s%s",svars[i].Data(),sunits[i].Data()));
-      varsDRPlot[i][j]->GetYaxis()->SetTitle("Duplicate Rate");    
-    }
-  }
-
-  //Initialize var_val/err arrays, SetBranchAddress
-  for (UInt_t i = 0; i < vars.size(); i++){ // loop over trks index
-    // initialize var
-    mcvars_val[i] = 0.;
-    
-    //Set var+trk branch
-    efftree->SetBranchAddress(Form("%s_mc_gen",vars[i].Data()),&(mcvars_val[i]));
-  }
-
-  //Initialize masks, set branch addresses  
-  for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-    mcmask_trk[j] = 0;
-    nTkMatches_trk[j] = 0;
-    
-    efftree->SetBranchAddress(Form("mcmask_%s",trks[j].Data()),&(mcmask_trk[j]));
-    efftree->SetBranchAddress(Form("nTkMatches_%s",trks[j].Data()),&(nTkMatches_trk[j]));
-  }
-
-  // Fill histos, compute DR from tree branches 
-  for (UInt_t k = 0; k < (UInt_t) efftree->GetEntries(); k++){
-    efftree->GetEntry(k);
-    for (UInt_t i = 0; i < vars.size(); i++){  // loop over vars index
-      for (UInt_t j = 0; j < trks.size(); j++){ // loop over trks index
-	if (mcmask_trk[j] == 1) {
-	  varsDenomPlot[i][j]->Fill(mcvars_val[i]);
-	  for (Int_t n = 0; n < nTkMatches_trk[j]; n++){
-	    varsNumerPlot[i][j]->Fill(mcvars_val[i]);
-	  } // fill n times sim track is matched. filled once is one sim to one reco.  filled twice is two reco to one sim
-	} // must be a matched track for proper denom
-      } // end loop over trks
-    } // end loop over vars
-  } // end loop over entry in tree
-
-  // Draw, divide, and save DR plots
-  for (UInt_t i = 0; i < vars.size(); i++){
-    for (UInt_t j = 0; j < trks.size(); j++){
-      PlotValidation::ComputeRatioPlot(varsNumerPlot[i][j],varsDenomPlot[i][j],varsDRPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsNumerPlot[i][j]);
-      PlotValidation::WriteTH1FPlot(subdir,varsDenomPlot[i][j]);
-      PlotValidation::DrawWriteSaveTH1FPlot(subdir,varsDRPlot[i][j],subdirname,Form("%s_DR_%s",vars[i].Data(),trks[j].Data()),zeroSupLin);
-      delete varsNumerPlot[i][j];
-      delete varsDenomPlot[i][j];
-      delete varsDRPlot[i][j];
-    }
-  }  
-  delete efftree;
+  delete cftree;
 }
 
 void PlotValidation::PrintTotals(){
@@ -1808,7 +1813,7 @@ void PlotValidation::PrintTotals(){
 
   // timing dump
   TTree * configtree = (TTree*)fInRoot->Get("configtree");
-  UInt_t  Ntracks = 0, Nevents = 0, nEtaPart = 0, nPhiPart = 0;
+  Int_t  Ntracks = 0, Nevents = 0, nEtaPart = 0, nPhiPart = 0;
   Float_t simtime = 0., segtime = 0., seedtime = 0., buildtime = 0., fittime = 0., hlvtime = 0.;
   configtree->SetBranchAddress("Nevents",&Nevents);
   configtree->SetBranchAddress("Ntracks",&Ntracks);

--- a/PlotValidation.cpp
+++ b/PlotValidation.cpp
@@ -1876,11 +1876,7 @@ void PlotValidation::PrintTotals(){
     
     std::cout << std::endl << "Rates for " << strks[j].Data() << " Tracks" << std::endl;
     std::cout << "==========================================" << std::endl;
-    std::cout << std::endl << "Rates for " << strks[j].Data() << " Tracks" << std::endl;
-    std::cout << "==========================================" << std::endl;
 
-    totalsout << std::endl << "Rates for " << strks[j].Data() << " Tracks" << std::endl;
-    totalsout << "==========================================" << std::endl;
     totalsout << std::endl << "Rates for " << strks[j].Data() << " Tracks" << std::endl;
     totalsout << "==========================================" << std::endl;
     for (UInt_t r = 0; r < rates.size(); r++) {

--- a/PlotValidation.hh
+++ b/PlotValidation.hh
@@ -15,46 +15,45 @@
 #include <fstream>
 #include <cmath>
 
-typedef std::vector<UInt_t> *   UIntVecRef;
-typedef std::vector<UIntVecRef> UIntVecRefVec;
-
+typedef std::vector<Float_t>      FltVec;
+typedef std::vector<FltVec>       FltVecVec;
+typedef std::vector<FltVecVec>    FltVecVecVec;
 typedef std::vector<Float_t> *    FltVecRef;
 typedef std::vector<FltVecRef>    FltVecRefVec;
 typedef std::vector<FltVecRefVec> FltVecRefVecVec;
 
-typedef std::vector<TString> TStrVec;
-
-typedef std::vector<UInt_t> UIntVec;
-
-typedef std::vector<Int_t>  IntVec;
-typedef std::vector<IntVec> IntVecVec;
-
-typedef std::vector<Float_t>   FltVec;
-typedef std::vector<FltVec>    FltVecVec;
-typedef std::vector<FltVecVec> FltVecVecVec;
+typedef std::vector<Int_t>     IntVec;
+typedef std::vector<IntVec>    IntVecVec;
+typedef std::vector<Int_t> *   IntVecRef;
+typedef std::vector<IntVecRef> IntVecRefVec;
 
 typedef std::vector<TH1F *>        TH1FRefVec;
 typedef std::vector<TH1FRefVec>    TH1FRefVecVec;
 typedef std::vector<TH1FRefVecVec> TH1FRefVecVecVec;
+
+typedef std::vector<TString> TStrVec;
 
 class PlotValidation
 {
 public:
   PlotValidation(TString inName, TString outName, TString outType);
   ~PlotValidation();
-  void Validation(Bool_t mvInput = false);
-  void PlotBranching();
-  void PlotTiming();
-  void PlotSegment();
-  void PlotSimGeo();
-  void PlotNHits();
-  void PlotCFResidual();
-  void PlotCFResolutionPull();
-  void PlotPosResolutionPull();
-  void PlotMomResolutionPull();
+  void Validation(Bool_t fullVal = false, Bool_t mvInput = false);
+
   void PlotEfficiency();
   void PlotFakeRate();
   void PlotDuplicateRate();
+  void PlotNHits();
+  void PlotTiming();
+  void PlotMomResolutionPull();
+
+  void PlotSegment();
+  void PlotBranching();
+  void PlotSimGeo();
+  void PlotPosResolutionPull();
+  void PlotCFResidual();
+  void PlotCFResolutionPull();
+
   void PrintTotals();
 
   void MakeSubDirectory(const TString subdirname);

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -64,8 +64,6 @@ TTreeValidation::TTreeValidation(std::string fileName)
 }
 
 void TTreeValidation::initializeSegmentTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
   // segment validation
   segtree_ = new TTree("segtree","segtree");
   segtree_->Branch("evtID",&evtID_seg_);
@@ -76,8 +74,6 @@ void TTreeValidation::initializeSegmentTree(){
 }
 
 void TTreeValidation::initializeBranchTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
   // build validation
   tree_br_ = new TTree("tree_br","tree_br");
   tree_br_->Branch("evtID",&evtID_br_);
@@ -99,8 +95,6 @@ void TTreeValidation::initializeBranchTree(){
 }
 
 void TTreeValidation::initializeEfficiencyTree(){  
-  std::lock_guard<std::mutex> locker(glock_);
-
   // efficiency validation
   efftree_ = new TTree("efftree","efftree");
   efftree_->Branch("evtID",&evtID_eff_);
@@ -180,8 +174,6 @@ void TTreeValidation::initializeEfficiencyTree(){
 }
 
 void TTreeValidation::initializeFakeRateTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
   // fake rate validation
   fakeratetree_ = new TTree("fakeratetree","fakeratetree");
 
@@ -268,8 +260,6 @@ void TTreeValidation::initializeFakeRateTree(){
 }
 
 void TTreeValidation::initializeGeometryTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
   // Geometry validation
   geotree_ = new TTree("geotree","geotree");
 
@@ -310,8 +300,6 @@ void TTreeValidation::initializeGeometryTree(){
 }
 
 void TTreeValidation::initializeConformalTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
   // Conformal Fit validation
   cftree_ = new TTree("cftree","cftree");
 
@@ -394,9 +382,7 @@ void TTreeValidation::initializeConformalTree(){
 }
 
 void TTreeValidation::initializeConfigTree(){
-  std::lock_guard<std::mutex> locker(glock_);
-
-  // include ALL config ++ real seeding parameters ...
+  // include config ++ real seeding parameters ...
   configtree_ = new TTree("configtree","configtree");
   configtree_->Branch("simtime",&simtime_);
   configtree_->Branch("segtime",&segtime_);

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -553,8 +553,8 @@ void TTreeValidation::mapSimTkToRecoTks(const TrackVec& evt_tracks, TrackExtraVe
 	tmpMatches.push_back(evt_tracks[label]);
       }
       std::sort(tmpMatches.begin(), tmpMatches.end(), sortByHitsChi2); // sort the tracks
-      for (auto itrack = 0; itrack < tmpMatches.size(); itrack++){ // loop over sorted tracks, now make the vector of sorted labels
-	simTkMatches.second[itrack] = evt_tracks[itrack].label();
+      for (auto itrack = 0; itrack < tmpMatches.size(); itrack++){ // loop over sorted tracks, now make the vector of sorted labels match
+ 	simTkMatches.second[itrack] = tmpMatches[itrack].label();
       }
       
       int duplicateID = 0;

--- a/TTreeValidation.h
+++ b/TTreeValidation.h
@@ -33,13 +33,14 @@ public:
   std::vector<int> branch_hit_indices; // size of was just branches
 };
 
+// Branch Tree type definitions
 typedef std::vector<BranchVal> BranchValVec;
 typedef std::unordered_map<int, BranchValVec> BranchValVecLayMap;
 typedef std::unordered_map<int, BranchValVecLayMap> TkIDToBranchValVecLayMapMap;
 typedef TkIDToBranchValVecLayMapMap::iterator TkIDToBVVMMIter;
 typedef BranchValVecLayMap::iterator BVVLMiter;
 
-// other typedefs
+// Map typedefs needed for mapping different sets of tracks to another
 typedef std::unordered_map<int,int>               TkIDToTkIDMap;
 typedef std::unordered_map<int,std::vector<int> > TkIDToTkIDVecMap;
 typedef std::unordered_map<int,TrackState>        TkIDToTSMap;   
@@ -50,83 +51,84 @@ class TTreeValidation : public Validation {
 public:
   TTreeValidation(std::string fileName);
 
-  void resetValidationMaps() override;
+  void initializeSegmentTree();
+  void initializeBranchTree();
+  void initializeEfficiencyTree();
+  void initializeFakeRateTree();  
+  void initializeGeometryTree();
+  void initializeConformalTree();
+  void initializeConfigTree();
   
   void alignTrackExtra(TrackVec& evt_tracks, TrackExtraVec& evt_extra) override;
 
   void collectSimTkTSVecMapInfo(int mcTrackID, const TSVec& initTSs) override;
-
   void collectSeedTkCFMapInfo(int seedID, const TrackState& cfitStateHit0) override;
   void collectSeedTkTSLayerPairVecMapInfo(int seedID, const TSLayerPairVec& updatedStates) override;
-
   void collectBranchingInfo(int seedID, int ilayer,
                             float nSigmaDeta, float etaBinMinus, int etaBinPlus,
                             float nSigmaDphi, int phiBinMinus, int phiBinPlus,
                             const std::vector<int>& cand_hit_indices, const std::vector<int>& cand_hits_branches) override;
-
   void collectFitTkCFMapInfo(int seedID, const TrackState& cfitStateHit0) override;
   void collectFitTkTSLayerPairVecMapInfo(int seedID, const TSLayerPairVec& updatedStates) override;
 
-  void fillSegmentTree(const BinInfoMap& segmentMap, int evtID) override;
-
-  void fillBranchTree(int evtID) override;
-
+  void resetValidationMaps() override;
   void makeSimTkToRecoTksMaps(Event& ev) override;
   void mapSimTkToRecoTks(const TrackVec& evt_tracks, TrackExtraVec& evt_extra, const std::vector<HitVec>& layerHits, 
 			 const MCHitInfoVec&, TkIDToTkIDVecMap& simTkMap);
-  void fillEffTree(const Event& ev) override;
-
   void makeSeedTkToRecoTkMaps(Event& ev) override;
   void mapSeedTkToRecoTk(const TrackVec& evt_tracks, const TrackExtraVec& evt_extras, TkIDToTkIDMap& seedTkMap);
-  void fillFakeRateTree(const Event& ev) override;
 
+  void fillSegmentTree(const BinInfoMap& segmentMap, int evtID) override;
+  void fillBranchTree(int evtID) override;
+  void fillEfficiencyTree(const Event& ev) override;
+  void fillFakeRateTree(const Event& ev) override;
+  void fillGeometryTree(const Event& ev) override;
+  void fillConformalTree(const Event& ev) override;
   void fillConfigTree(const std::vector<double>& ticks) override;
 
   void saveTTrees() override;
 
-  TFile* f_;
+ private:
+  TFile* f_; // output file!
 
-  // segment map tree
-  TTree* segtree_;
-  int evtID_seg_=0,layer_seg_=0,etabin_seg_=0,phibin_seg_=0,nHits_seg_=0;
+  TkIDToTSLayerPairVecMap seedTkTSLayerPairVecMap_; // used for position pulls for seed track
+  TkIDToTSLayerPairVecMap fitTkTSLayerPairVecMap_; //  used for position pulls for fit track
+  TkIDToBranchValVecLayMapMap seedToBranchValVecLayMapMap_; // map created inside collectBranchingInfo
 
-  // declare vector of trackStates for various track collections to be used in pulls/resolutions
-  TkIDToTSVecMap simTkTSVecMap_;
-  
-  TkIDToTSMap seedTkCFMap_;
-  TkIDToTSLayerPairVecMap seedTkTSLayerPairVecMap_;
+  TkIDToTSVecMap simTkTSVecMap_; // used for pulls (map all sim track TS to sim ID)
+  TkIDToTSMap seedTkCFMap_; // map CF TS to seedID of seed track
+  TkIDToTSMap fitTkCFMap_; // map CF TS to seedID of fit track
 
-  TkIDToBranchValVecLayMapMap seedToBranchValVecLayMapMap_;
-
-  TkIDToTSMap fitTkCFMap_;
-  TkIDToTSLayerPairVecMap fitTkTSLayerPairVecMap_;
-
-  // build branching tree
-  TTree* tree_br_;
-  int evtID_br_=0,seedID_br_=0;
-  int layer_=0,cands_=0;
-  int uniqueEtaPhiBins_,uniqueHits_,uniqueBranches_;
-  std::vector<int> candEtaPhiBins_,candHits_,candBranches_;
-  std::vector<float> candnSigmaDeta_,candnSigmaDphi_;
-  
-  // efficiency trees and variables
+  // Sim to Reco Maps
   TkIDToTkIDVecMap simToSeedMap_;
   TkIDToTkIDVecMap simToBuildMap_;
   TkIDToTkIDVecMap simToFitMap_;
 
-  TTree* efftree_;  
-  int evtID_eff_=0,mcID_eff_=0;
-  int mcmask_seed_eff_=0,mcmask_build_eff_=0,mcmask_fit_eff_=0;
+  // Reco to Reco Maps
+  TkIDToTkIDMap seedToBuildMap_;
+  TkIDToTkIDMap seedToFitMap_;
 
-  int seedID_seed_eff_=0,seedID_build_eff_=0,seedID_fit_eff_=0;
+  // segment map tree
+  TTree* segtree_;
+  int   evtID_seg_=0,layer_seg_=0,etabin_seg_=0,phibin_seg_=0,nHits_seg_=0;
+
+  // build branching tree
+  TTree* tree_br_;
+  int   evtID_br_=0,seedID_br_=0;
+  int   layer_=0,cands_=0;
+  int   uniqueEtaPhiBins_,uniqueHits_,uniqueBranches_;
+  std::vector<int> candEtaPhiBins_,candHits_,candBranches_;
+  std::vector<float> candnSigmaDeta_,candnSigmaDphi_;
+  
+  // Efficiency Tree 
+  TTree* efftree_;  
+  int   evtID_eff_=0,mcID_eff_=0;
+  int   mcmask_seed_eff_=0,mcmask_build_eff_=0,mcmask_fit_eff_=0;
+  int   seedID_seed_eff_=0,seedID_build_eff_=0,seedID_fit_eff_=0;
 
   // for efficiency and duplicate rate plots
   float pt_mc_gen_eff_=0.,phi_mc_gen_eff_=0.,eta_mc_gen_eff_=0.;
   int   nHits_mc_eff_=0;
-
-  // for position pulls and geo plots
-  std::vector<float> x_mc_reco_hit_eff_,y_mc_reco_hit_eff_,z_mc_reco_hit_eff_;
-  float x_mc_gen_vrx_eff_=0.,y_mc_gen_vrx_eff_=0.,z_mc_gen_vrx_eff_=0.;
 
   // for track resolutions / pulls
   float pt_mc_seed_eff_=0.,pt_mc_build_eff_=0.,pt_mc_fit_eff_=0.;
@@ -136,29 +138,12 @@ public:
   float eta_mc_seed_eff_=0.,eta_mc_build_eff_=0.,eta_mc_fit_eff_=0.;
   float eta_seed_eff_=0.,eta_build_eff_=0.,eta_fit_eff_=0.,eeta_seed_eff_=0.,eeta_build_eff_=0.,eeta_fit_eff_=0.;
   
-  // for conformal fit resolutions/pulls/residuals
-  float x_mc_cf_seed_eff_=0.,y_mc_cf_seed_eff_=0.,z_mc_cf_seed_eff_=0.,x_mc_cf_fit_eff_=0.,y_mc_cf_fit_eff_=0.,z_mc_cf_fit_eff_=0.;
-  float x_cf_seed_eff_=0.,y_cf_seed_eff_=0.,z_cf_seed_eff_=0.,x_cf_fit_eff_=0.,y_cf_fit_eff_=0.,z_cf_fit_eff_=0.;
-  float ex_cf_seed_eff_=0.,ey_cf_seed_eff_=0.,ez_cf_seed_eff_=0.,ex_cf_fit_eff_=0.,ey_cf_fit_eff_=0.,ez_cf_fit_eff_=0.;
-
-  float px_mc_cf_seed_eff_=0.,py_mc_cf_seed_eff_=0.,pz_mc_cf_seed_eff_=0.,px_mc_cf_fit_eff_=0.,py_mc_cf_fit_eff_=0.,pz_mc_cf_fit_eff_=0.;
-  float px_cf_seed_eff_=0.,py_cf_seed_eff_=0.,pz_cf_seed_eff_=0.,px_cf_fit_eff_=0.,py_cf_fit_eff_=0.,pz_cf_fit_eff_=0.;
-  float epx_cf_seed_eff_=0.,epy_cf_seed_eff_=0.,epz_cf_seed_eff_=0.,epx_cf_fit_eff_=0.,epy_cf_fit_eff_=0.,epz_cf_fit_eff_=0.;
-
-  float pt_mc_cf_seed_eff_=0.,invpt_mc_cf_seed_eff_=0.,phi_mc_cf_seed_eff_=0.,theta_mc_cf_seed_eff_=0.,pt_mc_cf_fit_eff_=0.,invpt_mc_cf_fit_eff_=0.,phi_mc_cf_fit_eff_=0.,theta_mc_cf_fit_eff_=0.;
-  float pt_cf_seed_eff_=0.,invpt_cf_seed_eff_=0.,phi_cf_seed_eff_=0.,theta_cf_seed_eff_=0.,pt_cf_fit_eff_=0.,invpt_cf_fit_eff_=0.,phi_cf_fit_eff_=0.,theta_cf_fit_eff_=0.;
-  float ept_cf_seed_eff_=0.,einvpt_cf_seed_eff_=0.,ephi_cf_seed_eff_=0.,etheta_cf_seed_eff_=0.,ept_cf_fit_eff_=0.,einvpt_cf_fit_eff_=0.,ephi_cf_fit_eff_=0.,etheta_cf_fit_eff_=0.;
-
-  // for position pulls
-  std::vector<float> x_lay_seed_eff_,y_lay_seed_eff_,z_lay_seed_eff_,x_lay_fit_eff_,y_lay_fit_eff_,z_lay_fit_eff_;
-  std::vector<float> ex_lay_seed_eff_,ey_lay_seed_eff_,ez_lay_seed_eff_,ex_lay_fit_eff_,ey_lay_fit_eff_,ez_lay_fit_eff_;
-  std::vector<int> layers_seed_eff_,layers_fit_eff_;
-
   // for hit countings
   int   nHits_seed_eff_=0,nHits_build_eff_=0,nHits_fit_eff_=0;
   int   nHitsMatched_seed_eff_=0,nHitsMatched_build_eff_=0,nHitsMatched_fit_eff_=0;
   float fracHitsMatched_seed_eff_=0,fracHitsMatched_build_eff_=0,fracHitsMatched_fit_eff_=0;
 
+  // chi2 of tracks
   float hitchi2_seed_eff_=0.,hitchi2_build_eff_=0.,hitchi2_fit_eff_=0.;
   float helixchi2_seed_eff_=0.,helixchi2_build_eff_=0.,helixchi2_fit_eff_=0.;
 
@@ -166,10 +151,7 @@ public:
   int   duplmask_seed_eff_=0,duplmask_build_eff_=0,duplmask_fit_eff_=0;
   int   nTkMatches_seed_eff_=0,nTkMatches_build_eff_=0,nTkMatches_fit_eff_=0;
 
-  // fake rate tree and variables
-  TkIDToTkIDMap seedToBuildMap_;
-  TkIDToTkIDMap seedToFitMap_;
-  
+  // Fake Rate tree and variables
   TTree* fakeratetree_;
   int   evtID_FR_=0,seedID_FR_=0;
 
@@ -196,7 +178,38 @@ public:
   int   duplmask_seed_FR_=0,duplmask_build_FR_=0,duplmask_fit_FR_=0;
   int   iTkMatches_seed_FR_=0,iTkMatches_build_FR_=0,iTkMatches_fit_FR_=0;
 
-  // configuration tree
+  // Geometry Tree 
+  TTree* geotree_;  
+  int   evtID_geo_=0,mcID_geo_=0;
+  int   mcmask_seed_geo_=0,mcmask_build_geo_=0,mcmask_fit_geo_=0;
+  int   seedID_seed_geo_=0,seedID_build_geo_=0,seedID_fit_geo_=0;
+
+  float x_mc_gen_vrx_geo_=0.,y_mc_gen_vrx_geo_=0.,z_mc_gen_vrx_geo_=0.;
+  std::vector<int>   layers_seed_geo_,layers_fit_geo_;
+  std::vector<float> x_mc_reco_hit_geo_,y_mc_reco_hit_geo_,z_mc_reco_hit_geo_;
+  std::vector<float> x_lay_seed_geo_,y_lay_seed_geo_,z_lay_seed_geo_,x_lay_fit_geo_,y_lay_fit_geo_,z_lay_fit_geo_;
+  std::vector<float> ex_lay_seed_geo_,ey_lay_seed_geo_,ez_lay_seed_geo_,ex_lay_fit_geo_,ey_lay_fit_geo_,ez_lay_fit_geo_;
+
+  // Conformal Tree 
+  TTree* cftree_;  
+  int   evtID_cf_=0,mcID_cf_=0;
+  int   mcmask_seed_cf_=0,mcmask_build_cf_=0,mcmask_fit_cf_=0;
+  int   seedID_seed_cf_=0,seedID_build_cf_=0,seedID_fit_cf_=0;
+
+  float x_mc_seed_cf_=0.,y_mc_seed_cf_=0.,z_mc_seed_cf_=0.,x_mc_fit_cf_=0.,y_mc_fit_cf_=0.,z_mc_fit_cf_=0.;
+  float x_seed_cf_=0.,y_seed_cf_=0.,z_seed_cf_=0.,x_fit_cf_=0.,y_fit_cf_=0.,z_fit_cf_=0.;
+  float ex_seed_cf_=0.,ey_seed_cf_=0.,ez_seed_cf_=0.,ex_fit_cf_=0.,ey_fit_cf_=0.,ez_fit_cf_=0.;
+
+  float px_mc_seed_cf_=0.,py_mc_seed_cf_=0.,pz_mc_seed_cf_=0.,px_mc_fit_cf_=0.,py_mc_fit_cf_=0.,pz_mc_fit_cf_=0.;
+  float px_seed_cf_=0.,py_seed_cf_=0.,pz_seed_cf_=0.,px_fit_cf_=0.,py_fit_cf_=0.,pz_fit_cf_=0.;
+  float epx_seed_cf_=0.,epy_seed_cf_=0.,epz_seed_cf_=0.,epx_fit_cf_=0.,epy_fit_cf_=0.,epz_fit_cf_=0.;
+
+  float pt_mc_seed_cf_=0.,invpt_mc_seed_cf_=0.,phi_mc_seed_cf_=0.,theta_mc_seed_cf_=0.,pt_mc_fit_cf_=0.,
+        invpt_mc_fit_cf_=0.,phi_mc_fit_cf_=0.,theta_mc_fit_cf_=0.;
+  float pt_seed_cf_=0.,invpt_seed_cf_=0.,phi_seed_cf_=0.,theta_seed_cf_=0.,pt_fit_cf_=0.,invpt_fit_cf_=0.,phi_fit_cf_=0.,theta_fit_cf_=0.;
+  float ept_seed_cf_=0.,einvpt_seed_cf_=0.,ephi_seed_cf_=0.,etheta_seed_cf_=0.,ept_fit_cf_=0.,einvpt_fit_cf_=0.,ephi_fit_cf_=0.,etheta_fit_cf_=0.;
+
+  // Configuration tree
   TTree* configtree_;
   float simtime_=0.,segtime_=0.,seedtime_=0.,buildtime_=0.,fittime_=0.,hlvtime_=0.;
   int   Ntracks_=0,Nevents_=0;

--- a/Validation.h
+++ b/Validation.h
@@ -7,31 +7,26 @@ class Event;
 
 class Validation {
 public:
-  virtual void resetValidationMaps() {}
-
   virtual void alignTrackExtra(TrackVec&, TrackExtraVec&) {}
 
-  virtual void collectSimTkTSVecMapInfo(int, const TSVec&) {}
+  virtual void resetValidationMaps() {}
+  virtual void makeSimTkToRecoTksMaps(Event&) {}
+  virtual void makeSeedTkToRecoTkMaps(Event&) {}
 
+  virtual void collectSimTkTSVecMapInfo(int, const TSVec&) {}
   virtual void collectSeedTkCFMapInfo(int, const TrackState&) {}
   virtual void collectSeedTkTSLayerPairVecMapInfo(int, const TSLayerPairVec&) {}
-
   virtual void collectBranchingInfo(int, int, float, float, int, float, int,
 				    int, const std::vector<int>&, const std::vector<int>&) {}
-
   virtual void collectFitTkCFMapInfo(int, const TrackState&) {}
   virtual void collectFitTkTSLayerPairVecMapInfo(int, const TSLayerPairVec&) {}
 
   virtual void fillSegmentTree(const BinInfoMap&, int) {}
-
   virtual void fillBranchTree(int) {}
-
-  virtual void makeSimTkToRecoTksMaps(Event&) {}
-  virtual void fillEffTree(const Event&) {}
-
-  virtual void makeSeedTkToRecoTkMaps(Event&) {}
+  virtual void fillEfficiencyTree(const Event&) {}
   virtual void fillFakeRateTree(const Event&) {}
-
+  virtual void fillGeometryTree(const Event&) {}
+  virtual void fillConformalTree(const Event&) {}
   virtual void fillConfigTree(const std::vector<double> &) {}
 
   virtual void saveTTrees() {}

--- a/mkFit/Makefile
+++ b/mkFit/Makefile
@@ -30,9 +30,6 @@ ifeq (${CXX},icc)
   EXES   += $(addsuffix -mic, ${TGTS})
 endif
 
-auto-matriplex:
-	${MAKE} -C ../Matriplex auto && touch $@
-
 AUTO_HEADERS := upParam_MultKalmanGain.ah \
 		upParam_simil_x_propErr.ah \
 		upParam_propErrT_x_simil_propErr.ah \
@@ -46,7 +43,7 @@ ${AUTO_HEADERS}: auto-genmplex
 auto-genmplex: GenMPlexOps.pl
 	./GenMPlexOps.pl
 
-AUTO_TGTS := auto-matriplex ${AUTO_HEADERS}
+AUTO_TGTS := ${AUTO_HEADERS}
 
 default: ${AUTO_TGTS} ${EXES}
 

--- a/runValidation.C
+++ b/runValidation.C
@@ -18,7 +18,14 @@ void runValidation() {
   // First is input name of root file
   // Second is output name of directory/rootfile/file plots
   // Third is output type of plots
-  
-  PlotValidation Validation("valtree.root","5000tk_100evts_630phi_10eta","pdf");
-  Validation.Validation(Bool_t(true)); // bool to move input root file to output directory
+
+  // Validation() has two boolean arguments
+  // First bool == true for full validation, false for only "main" validation.
+  // Main validation includes efficiencies, fake rates, duplicate rates. Also momentum pulls, nHits plots, timing plots.
+  // Full validation includes main validation plus geometry plots, positions pulls, and CF pulls/residuals.  
+  // Full validation also includes branching plots and segmenting plots
+  // The second boolean argument == true to move input root file to output directory, false to keep input file where it is.
+
+  PlotValidation Val("valtree.root","full_validation","pdf");
+  Val.Validation( Bool_t(false), Bool_t(true) ); 
 }


### PR DESCRIPTION
Incorporates back in the real seeding.  CF still yields problematic pT.

Seed finding efficiency is ~80%.  Can be increased by loosening z-cuts to get up 95% (with an increase in fake rate).

EDIT: Added a small commit to fix benchmarking scripts/plots (change from _host*VU8* to _host*VU8int*).

Ran benchmarking scripts, plots identical.  All commits can be merged automatically.  PR's are layered and have merged in all other changes since the first PR.
Reference: http://uaf-7.t2.ucsd.edu/~cerati/mictest/2016-01-20/
Target: https://www.dropbox.com/sh/hf3a4mvk6aw66eg/AADd6UeLEmqh6xRWK18L3F6Qa?dl=0