### PR TITLE
Use nfsmic for benchmarking

### DIFF
--- a/benchmark-fit.sh
+++ b/benchmark-fit.sh
@@ -5,12 +5,16 @@ sed -i 's/int nTracks = 20000/int nTracks = 1000000/g' Config.cc
 make clean
 make -j 8
 
+dir=/data/nfsmic/${USER}/tmp
+
+mkdir ${dir}
 ./mkFit/mkFit --write --file-name simtracks_10x1M.bin
+mv simtracks_10x1M.bin ${dir}/
 
 for nth in 1 3 7 21
 do
 echo nth=${nth}
-./mkFit/mkFit --read --file-name simtracks_10x1M.bin --fit-std-only --num-thr ${nth} >& log_host_10x1M_FIT_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x1M.bin --fit-std-only --num-thr ${nth} >& log_host_10x1M_FIT_NVU8int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -20,7 +24,7 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-./mkFit/mkFit --read --file-name simtracks_10x1M.bin --fit-std-only --num-thr 1 >& log_host_10x1M_FIT_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x1M.bin --fit-std-only --num-thr 1 >& log_host_10x1M_FIT_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/benchmark-mic-fit.sh
+++ b/benchmark-mic-fit.sh
@@ -1,17 +1,21 @@
 #! /bin/bash
 
-sed -i 's/int nTracks = 20000/int nTracks = 500000/g' Config.cc 
+sed -i 's/int nTracks = 20000/int nTracks = 1000000/g' Config.cc 
 
 make clean
 make -j 8
 
-./mkFit/mkFit --write --file-name simtracks_10x500k.bin
-scp simtracks_10x500k.bin mic0:
+dir=/data/nfsmic/${USER}/tmp
+micdir=/nfsmic/${USER}/tmp
+
+mkdir ${dir}
+./mkFit/mkFit --write --file-name simtracks_10x1M.bin
+mv simtracks_10x1M.bin ${dir}/
 
 for nth in 1 3 7 21 42 63 84 105 126 147 168 189 210
 do
 echo nth=${nth}
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x500k.bin --fit-std-only --num-thr ${nth} >& log_mic_10x500k_FIT_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x1M.bin --fit-std-only --num-thr ${nth} >& log_mic_10x1M_FIT_NVU16int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -21,7 +25,7 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x500k.bin --fit-std-only --num-thr 1 >& log_mic_10x500k_FIT_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x1M.bin --fit-std-only --num-thr 1 >& log_mic_10x1M_FIT_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/benchmark-mic-fit.sh
+++ b/benchmark-mic-fit.sh
@@ -30,7 +30,7 @@ sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config
 
-sed -i 's/int nTracks = 500000/int nTracks = 20000/g' Config.cc 
+sed -i 's/int nTracks = 1000000/int nTracks = 20000/g' Config.cc 
 
 make clean
 make -j 8

--- a/benchmark-mic.sh
+++ b/benchmark-mic.sh
@@ -5,16 +5,20 @@ sed -i 's/\/\/\#define PRINTOUTS_FOR_PLOTS/\#define PRINTOUTS_FOR_PLOTS/g' Confi
 make clean
 make -j 8
 
+dir=/data/nfsmic/${USER}/tmp
+micdir=/nfsmic/${USER}/tmp
+
+mkdir ${dir}
 ./mkFit/mkFit --write --file-name simtracks_10x20k.bin
-scp simtracks_10x20k.bin mic0:
+mv simtracks_10x20k.bin ${dir}/
 
 for nth in 1 3 7 21 42 63 84 105 126 147 168 189 210
 do
 echo nth=${nth}
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_mic_10x20k_BH_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_mic_10x20k_ST_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_mic_10x20k_CE_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_mic_10x20k_CEST_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_mic_10x20k_BH_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_mic_10x20k_ST_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_mic_10x20k_CE_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_mic_10x20k_CEST_NVU16int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -24,10 +28,10 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_mic_10x20k_BH_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-std --num-thr 1 >& log_mic_10x20k_ST_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_mic_10x20k_CE_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_mic_10x20k_CEST_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_mic_10x20k_BH_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-std --num-thr 1 >& log_mic_10x20k_ST_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_mic_10x20k_CE_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name ${micdir}/simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_mic_10x20k_CEST_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -5,15 +5,19 @@ sed -i 's/\/\/\#define PRINTOUTS_FOR_PLOTS/\#define PRINTOUTS_FOR_PLOTS/g' Confi
 make clean
 make -j 8
 
+dir=/data/nfsmic/${USER}/tmp
+
+mkdir ${dir}
 ./mkFit/mkFit --write --file-name simtracks_10x20k.bin
+mv simtracks_10x20k.bin ${dir}/
 
 for nth in 1 3 7 21
 do
 echo nth=${nth}
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_host_10x20k_BH_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_host_10x20k_ST_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_host_10x20k_CE_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_host_10x20k_CEST_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_host_10x20k_BH_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_host_10x20k_ST_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_host_10x20k_CE_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_host_10x20k_CEST_NVU8int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -23,10 +27,10 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_host_10x20k_BH_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-std --num-thr 1 >& log_host_10x20k_ST_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_host_10x20k_CE_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_host_10x20k_CEST_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_host_10x20k_BH_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-std --num-thr 1 >& log_host_10x20k_ST_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_host_10x20k_CE_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_host_10x20k_CEST_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/makeBenchmarkPlots.C
+++ b/makeBenchmarkPlots.C
@@ -25,7 +25,7 @@
   g_BH_VU->GetYaxis()->SetTitle("Time for 10 events x 20k tracks [s]");
   g_BH_VU->GetXaxis()->SetRangeUser(1,maxvu);
   g_BH_VU->GetYaxis()->SetRangeUser(0,10);
-  if (isMic) g_BH_VU->GetYaxis()->SetRangeUser(0,70);
+  if (isMic) g_BH_VU->GetYaxis()->SetRangeUser(0,80);
   g_BH_VU->SetLineWidth(2);
   g_CE_VU->SetLineWidth(2);
   g_CEST_VU->SetLineWidth(2);

--- a/makeBenchmarkPlots.py
+++ b/makeBenchmarkPlots.py
@@ -19,7 +19,6 @@ for test in ['BH','CE','CEST','ST','FIT']:
     if 'FIT' in test: 
         pos = 3
         ntks = '1M'
-        if hORm == 'mic': ntks = '500k'
     g_VU = ROOT.TGraph(4)
     g_VU_speedup = ROOT.TGraph(4)
     point = 0

--- a/makeBenchmarkPlotsFit.C
+++ b/makeBenchmarkPlotsFit.C
@@ -9,7 +9,6 @@
   if (isMic) label+=" Phi";
 
   TString ntrk = "1M";
-  if (isMic) ntrk = "500k";
 
   float maxvu = 8;
   if (isMic) maxvu = 16;

--- a/makeBenchmarkPlotsFit.C
+++ b/makeBenchmarkPlotsFit.C
@@ -24,7 +24,7 @@
   g_FIT_VU->GetYaxis()->SetTitle("Time for "+ntrk+" tracks [s]");
   g_FIT_VU->GetYaxis()->SetTitleOffset(1.25);
   g_FIT_VU->GetXaxis()->SetRangeUser(1,maxvu);
-  g_FIT_VU->GetYaxis()->SetRangeUser(0,1.2*g_FIT_VU->GetY()[0]);
+  g_FIT_VU->GetYaxis()->SetRangeUser(0,(isMic ? 45 : 8));
   g_FIT_VU->SetLineWidth(2);
   g_FIT_VU->SetLineColor(kBlue);
   g_FIT_VU->SetMarkerStyle(kFullCircle);
@@ -61,13 +61,14 @@
   c2.SaveAs(hORm+"_vu_fitspeedup.png");
 
   TCanvas c3;
+  if (isMic) c3.SetLogy();
   TGraph* g_FIT_TH = (TGraph*) f->Get("g_FIT_TH");
   g_FIT_TH->SetTitle("Parallelization benchmark on "+label);
   g_FIT_TH->GetXaxis()->SetTitle("Number of Threads");
   g_FIT_TH->GetYaxis()->SetTitle("Time for "+ntrk+" tracks [s]");
   g_FIT_TH->GetYaxis()->SetTitleOffset(1.25);
   g_FIT_TH->GetXaxis()->SetRangeUser(1,maxth);
-  g_FIT_TH->GetYaxis()->SetRangeUser(0,1.2*g_FIT_TH->GetY()[0]);
+  g_FIT_TH->GetYaxis()->SetRangeUser((isMic ? 0.01 : 0),(isMic ? 10 : 2));
   g_FIT_TH->SetLineWidth(2);
   g_FIT_TH->SetLineColor(kBlue);
   g_FIT_TH->SetMarkerStyle(kFullCircle);
@@ -78,7 +79,6 @@
   leg_TH->AddEntry(g_FIT_TH,"Fit","LP");
   leg_TH->Draw();
   c3.SetGridy();
-  if (isMic) c3.SetLogy();
   c3.Update();
   c3.SaveAs(hORm+"_th_fittime.png");
 


### PR DESCRIPTION
Three changes related to benchmarking:
- avoid scp of simulation file to mic0
- use 1M tracks for fit test on mic
- fix axis ranges in benchmarking plots

Results: http://uaf-6.t2.ucsd.edu/~cerati/mictest/2016-03-08-PR34/