### PR TITLE
Super debug mode: SMatrix 

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -2,8 +2,14 @@
 
 namespace Config
 {
+
+#ifdef SUPERDEBUG // to avoid include of Config.h
+  int nTracks = 1;
+  int nEvents = 100000;
+#else
   int nTracks = 20000;
   int nEvents = 10;
+#endif
 
   // Multi threading and Clone engine configuration
   int   numThreadsFinder = 1;

--- a/Config.cc
+++ b/Config.cc
@@ -2,14 +2,8 @@
 
 namespace Config
 {
-
-#ifdef SUPERDEBUG // to avoid include of Config.h
-  int nTracks = 1;
-  int nEvents = 100000;
-#else
   int nTracks = 20000;
   int nEvents = 10;
-#endif
 
   // Multi threading and Clone engine configuration
   int   numThreadsFinder = 1;
@@ -24,4 +18,7 @@ namespace Config
   int   finderReportBestOutOfN = 1;
 
   bool  useCMSGeom = false;
+
+  bool  super_debug = false;
+  bool  cf_seeding  = false;
 }

--- a/Config.h
+++ b/Config.h
@@ -8,11 +8,9 @@
 
 namespace Config
 {
-#ifdef SUPERDEBUG
-  constexpr bool super_debug = true;
-#else
-  constexpr bool super_debug = false;
-#endif
+  // super debug mode in SMatrix
+  extern bool super_debug;
+  extern bool cf_seeding;
 
   // math general --> from namespace TMath
   constexpr float    PI    = 3.14159265358979323846;

--- a/Config.h
+++ b/Config.h
@@ -8,6 +8,12 @@
 
 namespace Config
 {
+#ifdef SUPERDEBUG
+  constexpr bool super_debug = true;
+#else
+  constexpr bool super_debug = false;
+#endif
+
   // math general --> from namespace TMath
   constexpr float    PI    = 3.14159265358979323846;
   constexpr float TwoPI    = 6.28318530717958647692;

--- a/Event.cc
+++ b/Event.cc
@@ -60,6 +60,9 @@ Event::Event(const Geometry& g, Validation& v, int evtID, int threads) : geom_(g
   segmentMap_.resize(Config::nLayers);
 
   validation_.resetValidationMaps(); // need to reset maps for every event.
+  if (Config::super_debug) {
+    validation_.resetDebugVectors(); // need to reset vectors for every event.
+  }
 }
 
 void Event::Simulate()
@@ -218,6 +221,7 @@ void Event::Segment()
 #ifdef ENDTOEND
   buildSeedsByRoadTriplets(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
   //buildSeedsByRZFirstRPhiSecond(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
+  //buildSeedsByMC(simTracks_,seedTracks_,seedTracksExtra_,*this);
 #else
   buildSeedsByMC(simTracks_,seedTracks_,seedTracksExtra_,*this);
 #endif
@@ -247,14 +251,19 @@ void Event::Fit()
 
 void Event::Validate(int ievt){
   // KM: Config tree just filled once... in main.cc
-  validation_.makeSimTkToRecoTksMaps(*this);
-  validation_.makeSeedTkToRecoTkMaps(*this);
-  validation_.fillSegmentTree(segmentMap_,ievt);
-  validation_.fillBranchTree(ievt);
-  validation_.fillEfficiencyTree(*this);
-  validation_.fillFakeRateTree(*this);
-  validation_.fillGeometryTree(*this);
-  validation_.fillConformalTree(*this);
+  if (!Config::super_debug){ // regular validation
+    validation_.makeSimTkToRecoTksMaps(*this);
+    validation_.makeSeedTkToRecoTkMaps(*this);
+    validation_.fillSegmentTree(segmentMap_,ievt);
+    validation_.fillBranchTree(ievt);
+    validation_.fillEfficiencyTree(*this);
+    validation_.fillFakeRateTree(*this);
+    validation_.fillGeometryTree(*this);
+    validation_.fillConformalTree(*this);
+  }
+  else{ // super debug mode
+    validation_.fillDebugTree(*this);
+  }
 }
 
 void Event::PrintStats(const TrackVec& trks, TrackExtraVec& trkextras)

--- a/Event.cc
+++ b/Event.cc
@@ -221,9 +221,9 @@ void Event::Segment()
 #ifdef ENDTOEND
   buildSeedsByRoadTriplets(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
   //buildSeedsByRZFirstRPhiSecond(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
-  //buildSeedsByMC(simTracks_,seedTracks_,seedTracksExtra_,*this);
 #else
   buildSeedsByMC(simTracks_,seedTracks_,seedTracksExtra_,*this);
+  simTracksExtra_ = seedTracksExtra_;
 #endif
   std::sort(seedTracks_.begin(), seedTracks_.end(), tracksByPhi);
   validation_.alignTrackExtra(seedTracks_,seedTracksExtra_);   // if we sort here, also have to sort seedTracksExtra and redo labels.

--- a/Event.h
+++ b/Event.h
@@ -44,7 +44,7 @@ public:
 
   TrackVec simTracks_, seedTracks_, candidateTracks_, fitTracks_;
   // validation sets these, so needs to be mutable
-  mutable TrackExtraVec seedTracksExtra_, candidateTracksExtra_, fitTracksExtra_;
+  mutable TrackExtraVec simTracksExtra_, seedTracksExtra_, candidateTracksExtra_, fitTracksExtra_;
 
   // phi-eta partitioning map: vector of vector of vectors of std::pairs. 
   // vec[nLayers][nEtaBins][nPhiBins]

--- a/Hit.h
+++ b/Hit.h
@@ -209,6 +209,15 @@ public:
   float z() const {
     return state_.parameters().At(2);
   }
+  float exx() const {
+    return state_.errors().At(0,0);
+  }
+  float eyy() const {
+    return state_.errors().At(1,1);
+  }
+  float ezz() const {
+    return state_.errors().At(2,2);
+  }
   float phi() const {
     return getPhi(state_.parameters().At(0), state_.parameters().At(1));
   }

--- a/Makefile.config
+++ b/Makefile.config
@@ -93,8 +93,8 @@ GEN_FLAT_ETA := -DGENFLATETA
 # 16. Use inward fit in Conformal fit + final KF Fit
 INWARD_FIT := -DINWARDFIT
 
-# 17. Super debug mode --> allows really deep exploration of all props/updates etc with single track events, no skipping, in SMatrix
-#SUPER_DEBUG := -DSUPERDEBUG
+# 17. Super debug mode --> allows really deep exploration of all props/updates etc with single track events, no skipping, in SMatrix, "yes" is irrevelant
+#SUPER_DEBUG := yes
 
 ################################################################
 # Derived settings
@@ -166,7 +166,7 @@ else
 endif
 
 ifdef SUPER_DEBUG
-  CPPFLAGS := -I. -DCHECKSTATEVALID -DLINEARINTERP -DENDTOEND -DETASEG -DINWARDFIT -DGENFLATETA -DSUPERDEBUG $(shell root-config --cflags)
+  CPPFLAGS := -I. -DCHECKSTATEVALID -DLINEARINTERP -DETASEG -DINWARDFIT -DGENFLATETA $(shell root-config --cflags)
   CXXFLAGS := -O3 -g
   LDFLAGS  := $(shell root-config --libs)
 endif

--- a/Makefile.config
+++ b/Makefile.config
@@ -93,6 +93,9 @@ GEN_FLAT_ETA := -DGENFLATETA
 # 16. Use inward fit in Conformal fit + final KF Fit
 INWARD_FIT := -DINWARDFIT
 
+# 17. Super debug mode --> allows really deep exploration of all props/updates etc with single track events, no skipping, in SMatrix
+#SUPER_DEBUG := -DSUPERDEBUG
+
 ################################################################
 # Derived settings
 ################################################################
@@ -160,6 +163,12 @@ ifdef WITH_ROOT
   LDFLAGS  += $(shell root-config --libs)
 else
   CPPFLAGS += -DNO_ROOT
+endif
+
+ifdef SUPER_DEBUG
+  CPPFLAGS := -I. -DCHECKSTATEVALID -DLINEARINTERP -DENDTOEND -DETASEG -DINWARDFIT -DGENFLATETA -DSUPERDEBUG $(shell root-config --cflags)
+  CXXFLAGS := -O3 -g
+  LDFLAGS  := $(shell root-config --libs)
 endif
 
 ################################################################

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -54,15 +54,147 @@ TTreeValidation::TTreeValidation(std::string fileName)
   gROOT->ProcessLine("#include <vector>");
   f_ = TFile::Open(fileName.c_str(), "recreate");
 
-  initializeSeedInfoTree();
-  initializeSeedTree();
-  initializeSegmentTree();
-  initializeBranchTree();
-  initializeEfficiencyTree();
-  initializeFakeRateTree();  
-  initializeGeometryTree();
-  initializeConformalTree();
+  if (!Config::super_debug) { // regular validation
+    initializeSeedInfoTree();
+    initializeSeedTree();
+    initializeSegmentTree();
+    initializeBranchTree();
+    initializeEfficiencyTree();
+    initializeFakeRateTree();  
+    initializeGeometryTree();
+    initializeConformalTree();
+  }
+  else {
+    initializeDebugTree();
+  }
   initializeConfigTree();
+}
+
+void TTreeValidation::initializeDebugTree(){
+  nlayers_debug_ = Config::nLayers;
+
+  // debug tree(lots and lots of variables)
+  debugtree_ = new TTree("debugtree","debugtree");
+
+  debugtree_->Branch("nlayers",&nlayers_debug_,"nlayers_debug_/I");
+
+  debugtree_->Branch("recocharge",&recocharge_debug_,"recocharge/I");
+  debugtree_->Branch("mccharge",&mccharge_debug_,"mccharge/I");
+
+  debugtree_->Branch("event",&event_debug_,"event/I");
+  debugtree_->Branch("nHits",&nHits_debug_,"nHits/I");
+
+  debugtree_->Branch("pt_gen",&pt_gen_debug_,"pt_gen/F");
+  debugtree_->Branch("phi_gen",&phi_gen_debug_,"phi_gen/F");
+  debugtree_->Branch("eta_gen",&eta_gen_debug_,"eta_gen/F");
+
+  debugtree_->Branch("layer_mc",&layer_mc_debug_,"layer_mc[nlayers_debug_]/I");
+
+  debugtree_->Branch("layer_chi2",&layer_chi2_debug_,"layer_chi2[nlayers_debug_]/I");
+  debugtree_->Branch("chi2",&chi2_debug_,"chi2[nlayers_debug_]/F");
+
+  // MC
+  debugtree_->Branch("x_mc",&x_mc_debug_,"x_mc[nlayers_debug_]/F");
+  debugtree_->Branch("y_mc",&y_mc_debug_,"y_mc[nlayers_debug_]/F");
+  debugtree_->Branch("z_mc",&z_mc_debug_,"z_mc[nlayers_debug_]/F");
+  debugtree_->Branch("exx_mc",&exx_mc_debug_,"exx_mc[nlayers_debug_]/F");
+  debugtree_->Branch("eyy_mc",&eyy_mc_debug_,"eyy_mc[nlayers_debug_]/F");
+  debugtree_->Branch("ezz_mc",&ezz_mc_debug_,"ezz_mc[nlayers_debug_]/F");
+
+  debugtree_->Branch("px_mc",&px_mc_debug_,"px_mc[nlayers_debug_]/F");
+  debugtree_->Branch("py_mc",&py_mc_debug_,"py_mc[nlayers_debug_]/F");
+  debugtree_->Branch("pz_mc",&pz_mc_debug_,"pz_mc[nlayers_debug_]/F");
+
+  debugtree_->Branch("pt_mc",&pt_mc_debug_,"pt_mc[nlayers_debug_]/F");
+  debugtree_->Branch("phi_mc",&phi_mc_debug_,"phi_mc[nlayers_debug_]/F");
+  debugtree_->Branch("eta_mc",&eta_mc_debug_,"eta_mc[nlayers_debug_]/F");
+  debugtree_->Branch("invpt_mc",&invpt_mc_debug_,"invpt_mc[nlayers_debug_]/F");
+  debugtree_->Branch("theta_mc",&theta_mc_debug_,"theta_mc[nlayers_debug_]/F");
+
+  // conformal
+  debugtree_->Branch("x_cf",&x_cf_debug_,"x_cf/F");
+  debugtree_->Branch("y_cf",&y_cf_debug_,"y_cf/F");
+  debugtree_->Branch("z_cf",&z_cf_debug_,"z_cf/F");
+  debugtree_->Branch("exx_cf",&exx_cf_debug_,"exx_cf/F");
+  debugtree_->Branch("eyy_cf",&eyy_cf_debug_,"eyy_cf/F");
+  debugtree_->Branch("ezz_cf",&ezz_cf_debug_,"ezz_cf/F");
+
+  debugtree_->Branch("px_cf",&px_cf_debug_,"px_cf/F");
+  debugtree_->Branch("py_cf",&py_cf_debug_,"py_cf/F");
+  debugtree_->Branch("pz_cf",&pz_cf_debug_,"pz_cf/F");
+  debugtree_->Branch("epxpx_cf",&epxpx_cf_debug_,"epxpx_cf/F");
+  debugtree_->Branch("epypy_cf",&epypy_cf_debug_,"epypy_cf/F");
+  debugtree_->Branch("epzpz_cf",&epzpz_cf_debug_,"epzpz_cf/F");
+
+  debugtree_->Branch("pt_cf",&pt_cf_debug_,"pt_cf/F");
+  debugtree_->Branch("phi_cf",&phi_cf_debug_,"phi_cf/F");
+  debugtree_->Branch("eta_cf",&eta_cf_debug_,"eta_cf/F");
+  debugtree_->Branch("ept_cf",&ept_cf_debug_,"ept_cf/F");
+  debugtree_->Branch("ephi_cf",&ephi_cf_debug_,"ephi_cf/F");
+  debugtree_->Branch("eeta_cf",&eeta_cf_debug_,"eeta_cf/F");
+
+  debugtree_->Branch("invpt_cf",&invpt_cf_debug_,"invpt_cf/F");
+  debugtree_->Branch("einvpt_cf",&einvpt_cf_debug_,"einvpt_cf/F");
+  debugtree_->Branch("theta_cf",&theta_cf_debug_,"theta_cf/F");
+  debugtree_->Branch("etheta_cf",&etheta_cf_debug_,"etheta_cf/F");
+
+  // prop
+  debugtree_->Branch("layer_prop",&layer_prop_debug_,"layer_prop[nlayers_debug_]/I");
+
+  debugtree_->Branch("x_prop",&x_prop_debug_,"x_prop[nlayers_debug_]/F");
+  debugtree_->Branch("y_prop",&y_prop_debug_,"y_prop[nlayers_debug_]/F");
+  debugtree_->Branch("z_prop",&z_prop_debug_,"z_prop[nlayers_debug_]/F");
+  debugtree_->Branch("exx_prop",&exx_prop_debug_,"exx_prop[nlayers_debug_]/F");
+  debugtree_->Branch("eyy_prop",&eyy_prop_debug_,"eyy_prop[nlayers_debug_]/F");
+  debugtree_->Branch("ezz_prop",&ezz_prop_debug_,"ezz_prop[nlayers_debug_]/F");
+
+  debugtree_->Branch("px_prop",&px_prop_debug_,"px_prop[nlayers_debug_]/F");
+  debugtree_->Branch("py_prop",&py_prop_debug_,"py_prop[nlayers_debug_]/F");
+  debugtree_->Branch("pz_prop",&pz_prop_debug_,"pz_prop[nlayers_debug_]/F");
+  debugtree_->Branch("epxpx_prop",&epxpx_prop_debug_,"epxpx_prop[nlayers_debug_]/F");
+  debugtree_->Branch("epypy_prop",&epypy_prop_debug_,"epypy_prop[nlayers_debug_]/F");
+  debugtree_->Branch("epzpz_prop",&epzpz_prop_debug_,"epzpz_prop[nlayers_debug_]/F");
+
+  debugtree_->Branch("pt_prop",&pt_prop_debug_,"pt_prop[nlayers_debug_]/F");
+  debugtree_->Branch("phi_prop",&phi_prop_debug_,"phi_prop[nlayers_debug_]/F");
+  debugtree_->Branch("eta_prop",&eta_prop_debug_,"eta_prop[nlayers_debug_]/F");
+  debugtree_->Branch("ept_prop",&ept_prop_debug_,"ept_prop[nlayers_debug_]/F");
+  debugtree_->Branch("ephi_prop",&ephi_prop_debug_,"ephi_prop[nlayers_debug_]/F");
+  debugtree_->Branch("eeta_prop",&eeta_prop_debug_,"eeta_prop[nlayers_debug_]/F");
+
+  debugtree_->Branch("invpt_prop",&invpt_prop_debug_,"invpt_prop[nlayers_debug_]/F");
+  debugtree_->Branch("einvpt_prop",&einvpt_prop_debug_,"einvpt_prop[nlayers_debug_]/F");
+  debugtree_->Branch("theta_prop",&theta_prop_debug_,"theta_prop[nlayers_debug_]/F");
+  debugtree_->Branch("etheta_prop",&etheta_prop_debug_,"etheta_prop[nlayers_debug_]/F");
+
+  //update
+  debugtree_->Branch("layer_up",&layer_up_debug_,"layer_up[nlayers_debug_]/I");
+
+  debugtree_->Branch("x_up",&x_up_debug_,"x_up[nlayers_debug_]/F");
+  debugtree_->Branch("y_up",&y_up_debug_,"y_up[nlayers_debug_]/F");
+  debugtree_->Branch("z_up",&z_up_debug_,"z_up[nlayers_debug_]/F");
+  debugtree_->Branch("exx_up",&exx_up_debug_,"exx_up[nlayers_debug_]/F");
+  debugtree_->Branch("eyy_up",&eyy_up_debug_,"eyy_up[nlayers_debug_]/F");
+  debugtree_->Branch("ezz_up",&ezz_up_debug_,"ezz_up[nlayers_debug_]/F");
+
+  debugtree_->Branch("px_up",&px_up_debug_,"px_up[nlayers_debug_]/F");
+  debugtree_->Branch("py_up",&py_up_debug_,"py_up[nlayers_debug_]/F");
+  debugtree_->Branch("pz_up",&pz_up_debug_,"pz_up[nlayers_debug_]/F");
+  debugtree_->Branch("epxpx_up",&epxpx_up_debug_,"epxpx_up[nlayers_debug_]/F");
+  debugtree_->Branch("epypy_up",&epypy_up_debug_,"epypy_up[nlayers_debug_]/F");
+  debugtree_->Branch("epzpz_up",&epzpz_up_debug_,"epzpz_up[nlayers_debug_]/F");
+
+  debugtree_->Branch("pt_up",&pt_up_debug_,"pt_up[nlayers_debug_]/F");
+  debugtree_->Branch("phi_up",&phi_up_debug_,"phi_up[nlayers_debug_]/F");
+  debugtree_->Branch("eta_up",&eta_up_debug_,"eta_up[nlayers_debug_]/F");
+  debugtree_->Branch("ept_up",&ept_up_debug_,"ept_up[nlayers_debug_]/F");
+  debugtree_->Branch("ephi_up",&ephi_up_debug_,"ephi_up[nlayers_debug_]/F");
+  debugtree_->Branch("eeta_up",&eeta_up_debug_,"eeta_up[nlayers_debug_]/F");
+
+  debugtree_->Branch("invpt_up",&invpt_up_debug_,"invpt_up[nlayers_debug_]/F");
+  debugtree_->Branch("einvpt_up",&einvpt_up_debug_,"einvpt_up[nlayers_debug_]/F");
+  debugtree_->Branch("theta_up",&theta_up_debug_,"theta_up[nlayers_debug_]/F");
+  debugtree_->Branch("etheta_up",&etheta_up_debug_,"etheta_up[nlayers_debug_]/F");
 }
 
 void TTreeValidation::initializeSeedInfoTree(){
@@ -520,6 +652,18 @@ void TTreeValidation::collectFitTkTSLayerPairVecMapInfo(int seedID, const TSLaye
   fitTkTSLayerPairVecMap_[seedID] = updatedStates;
 }
 
+void TTreeValidation::collectPropTSLayerVecInfo(int layer, const TrackState& propTS){
+  propTSLayerPairVec_.push_back(std::make_pair(layer,propTS)); 
+}
+
+void TTreeValidation::collectChi2LayerVecInfo(int layer, float chi2){
+  chi2LayerPairVec_.push_back(std::make_pair(layer,chi2)); 
+}
+
+void TTreeValidation::collectUpTSLayerVecInfo(int layer, const TrackState& upTS){
+  upTSLayerPairVec_.push_back(std::make_pair(layer,upTS)); 
+}
+
 void TTreeValidation::resetValidationMaps(){
   std::lock_guard<std::mutex> locker(glock_);
   
@@ -545,6 +689,14 @@ void TTreeValidation::resetValidationMaps(){
   // reset map of seed tracks to reco tracks
   seedToBuildMap_.clear();
   seedToFitMap_.clear();
+}
+
+void TTreeValidation::resetDebugVectors(){
+  std::lock_guard<std::mutex> locker(glock_);
+  
+  propTSLayerPairVec_.clear(); // used exclusively for debugtree (prop states)
+  chi2LayerPairVec_.clear();   // used exclusively for debugtree 
+  upTSLayerPairVec_.clear();   // used exclusively for debugtree (updated states)
 }
 
 void TTreeValidation::makeSimTkToRecoTksMaps(Event& ev){
@@ -606,6 +758,195 @@ void TTreeValidation::mapSeedTkToRecoTk(const TrackVec& evt_tracks, const TrackE
   for (auto&& track : evt_tracks){
     seedTkMap[evt_extras[track.label()].seedID()] = track.label();
   }
+}
+
+void TTreeValidation::resetDebugTreeArrays(){
+  for (int i = 0; i < Config::nLayers; i++){
+    // reset MC info
+    layer_mc_debug_[i]=-99;
+    x_mc_debug_[i]=-99;     y_mc_debug_[i]=-99;     z_mc_debug_[i]=-99; 
+    exx_mc_debug_[i]=-99;   eyy_mc_debug_[i]=-99;   ezz_mc_debug_[i]=-99;
+    px_mc_debug_[i]=-99;    py_mc_debug_[i]=-99;    pz_mc_debug_[i]=-99;
+    pt_mc_debug_[i]=-99;    phi_mc_debug_[i]=-99;   eta_mc_debug_[i]=-99;
+    invpt_mc_debug_[i]=-99; theta_mc_debug_[i]=-99;
+
+    // reset prop info
+    layer_prop_debug_[i]=-99;
+    x_prop_debug_[i]=-99;      y_prop_debug_[i]=-99;      z_prop_debug_[i]=-99;
+    exx_prop_debug_[i]=-99;    eyy_prop_debug_[i]=-99;    ezz_prop_debug_[i]=-99;
+    px_prop_debug_[i]=-99;     py_prop_debug_[i]=-99;     pz_prop_debug_[i]=-99;
+    epxpx_prop_debug_[i]=-99;  epypy_prop_debug_[i]=-99;  epzpz_prop_debug_[i]=-99;
+    pt_prop_debug_[i]=-99;     phi_prop_debug_[i]=-99;    eta_prop_debug_[i]=-99;
+    ept_prop_debug_[i]=-99;    ephi_prop_debug_[i]=-99;   eeta_prop_debug_[i]=-99;
+    invpt_prop_debug_[i] =-99; theta_prop_debug_[i] =-99;
+    einvpt_prop_debug_[i]=-99; etheta_prop_debug_[i]=-99;
+
+    // reset chi2
+    layer_chi2_debug_[i]=-99;
+    chi2_debug_[i]=-99;
+
+    // reset update info
+    layer_up_debug_[i]=99;
+    x_up_debug_[i]=-99;      y_up_debug_[i]=-99;      z_up_debug_[i]=-99;
+    exx_up_debug_[i]=-99;    eyy_up_debug_[i]=-99;    ezz_up_debug_[i]=-99;
+    px_up_debug_[i]=-99;     py_up_debug_[i]=-99;     pz_up_debug_[i]=-99;
+    epxpx_up_debug_[i]=-99;  epypy_up_debug_[i]=-99;  epzpz_up_debug_[i]=-99;
+    pt_up_debug_[i]=-99;     phi_up_debug_[i]=-99;    eta_up_debug_[i]=-99;
+    ept_up_debug_[i]=-99;    ephi_up_debug_[i]=-99;   eeta_up_debug_[i]=-99;
+    invpt_up_debug_[i] =-99; theta_up_debug_[i] =-99;
+    einvpt_up_debug_[i]=-99; etheta_up_debug_[i]=-99;
+  }
+}
+
+void TTreeValidation::fillDebugTree(const Event& ev){
+  std::lock_guard<std::mutex> locker(glock_);
+  resetDebugTreeArrays();
+  
+  auto& simtrack   = ev.simTracks_[0];       // since it is the only one!
+  auto& seedtrack  = ev.seedTracks_[0];      // since it is the only one! 
+  auto& buildtrack = ev.candidateTracks_[0]; // since it is the only one! 
+
+  int mcID   = simtrack.label();
+  int seedID = ev.seedTracksExtra_[seedtrack.label()].seedID(); 
+
+  event_debug_ = ev.evtID();
+  nHits_debug_ = buildtrack.nFoundHits();
+
+  recocharge_debug_ = seedtrack.charge(); 
+  mccharge_debug_   = simtrack.charge();
+
+  // Set MC First
+  pt_gen_debug_  = simtrack.pT(); 
+  phi_gen_debug_ = simtrack.momPhi(); 
+  eta_gen_debug_ = simtrack.momEta(); 
+
+  auto& simhits = simtrack.hitsVector(ev.layerHits_);
+  for (int i = 0; i < simhits.size(); i++){ // assume one hit for layer for sim tracks...
+    layer_mc_debug_[i] = i;
+
+    x_mc_debug_[i] = simhits[i].x();
+    y_mc_debug_[i] = simhits[i].y();
+    z_mc_debug_[i] = simhits[i].z();
+    exx_mc_debug_[i] = simhits[i].exx();
+    eyy_mc_debug_[i] = simhits[i].eyy();
+    ezz_mc_debug_[i] = simhits[i].ezz();
+
+    const TrackState & mcstate = simTkTSVecMap_[mcID][i];
+    pt_mc_debug_[i]  = mcstate.pT();
+    phi_mc_debug_[i] = mcstate.momPhi();
+    eta_mc_debug_[i] = mcstate.momEta();
+
+    px_mc_debug_[i]  = mcstate.px();
+    py_mc_debug_[i]  = mcstate.py();
+    pz_mc_debug_[i]  = mcstate.pz();
+      
+    invpt_mc_debug_[i] = mcstate.invpT();
+    theta_mc_debug_[i] = mcstate.theta();
+  }
+
+  // CF next
+  const TrackState & cfSeedTS = seedTkCFMap_[seedID];
+  x_cf_debug_   = cfSeedTS.x();
+  y_cf_debug_   = cfSeedTS.y();
+  z_cf_debug_   = cfSeedTS.z();
+  exx_cf_debug_ = cfSeedTS.exx();
+  eyy_cf_debug_ = cfSeedTS.eyy();
+  ezz_cf_debug_ = cfSeedTS.ezz();
+
+  px_cf_debug_    = cfSeedTS.px();
+  py_cf_debug_    = cfSeedTS.py();
+  pz_cf_debug_    = cfSeedTS.pz();
+  epxpx_cf_debug_ = cfSeedTS.epxpx();
+  epypy_cf_debug_ = cfSeedTS.epypy();
+  epzpz_cf_debug_ = cfSeedTS.epzpz();
+
+  pt_cf_debug_   = cfSeedTS.pT();
+  phi_cf_debug_  = cfSeedTS.momPhi();
+  eta_cf_debug_  = cfSeedTS.momEta();
+  ept_cf_debug_  = cfSeedTS.epT();
+  ephi_cf_debug_ = cfSeedTS.emomPhi();
+  eeta_cf_debug_ = cfSeedTS.emomEta();
+
+  invpt_cf_debug_  = cfSeedTS.invpT();
+  einvpt_cf_debug_ = cfSeedTS.einvpT();
+  theta_cf_debug_  = cfSeedTS.theta();
+  etheta_cf_debug_ = cfSeedTS.etheta();
+
+  // prop states
+  for (int i = 0; i < propTSLayerPairVec_.size(); i++){
+    int layer = propTSLayerPairVec_[i].first; 
+    layer_prop_debug_[layer] = layer;
+	
+    const TrackState & propTS = propTSLayerPairVec_[i].second;
+    x_prop_debug_[layer]   = propTS.x();
+    y_prop_debug_[layer]   = propTS.y();
+    z_prop_debug_[layer]   = propTS.z();
+    exx_prop_debug_[layer] = propTS.exx();
+    eyy_prop_debug_[layer] = propTS.eyy();
+    ezz_prop_debug_[layer] = propTS.ezz();
+
+    px_prop_debug_[layer]    = propTS.px();
+    py_prop_debug_[layer]    = propTS.py();
+    pz_prop_debug_[layer]    = propTS.pz();
+    epxpx_prop_debug_[layer] = propTS.epxpx();
+    epypy_prop_debug_[layer] = propTS.epypy();
+    epzpz_prop_debug_[layer] = propTS.epzpz();
+
+    pt_prop_debug_[layer]   = propTS.pT();
+    phi_prop_debug_[layer]  = propTS.momPhi();
+    eta_prop_debug_[layer]  = propTS.momEta();
+    ept_prop_debug_[layer]  = propTS.epT();
+    ephi_prop_debug_[layer] = propTS.emomPhi();
+    eeta_prop_debug_[layer] = propTS.emomEta();
+
+    invpt_prop_debug_[layer]  = propTS.invpT();
+    einvpt_prop_debug_[layer] = propTS.einvpT();
+    theta_prop_debug_[layer]  = propTS.theta();
+    etheta_prop_debug_[layer] = propTS.etheta();
+  }
+    
+  // do the chi2
+  for (int i = 0; i < chi2LayerPairVec_.size(); i++){
+    int layer = chi2LayerPairVec_[i].first; 
+    layer_chi2_debug_[layer] = layer;
+    chi2_debug_[layer]       = chi2LayerPairVec_[i].second; 
+  }
+
+  // updated states 
+  for (int i = 0; i < upTSLayerPairVec_.size(); i++){
+    int layer = upTSLayerPairVec_[i].first; 
+    layer_up_debug_[layer] = layer;
+	
+    const TrackState & upTS = upTSLayerPairVec_[i].second;
+    x_up_debug_[layer]   = upTS.x();
+    y_up_debug_[layer]   = upTS.y();
+    z_up_debug_[layer]   = upTS.z();
+    exx_up_debug_[layer] = upTS.exx();
+    eyy_up_debug_[layer] = upTS.eyy();
+    ezz_up_debug_[layer] = upTS.ezz();
+
+    px_up_debug_[layer]    = upTS.px();
+    py_up_debug_[layer]    = upTS.py();
+    pz_up_debug_[layer]    = upTS.pz();
+    epxpx_up_debug_[layer] = upTS.epxpx();
+    epypy_up_debug_[layer] = upTS.epypy();
+    epzpz_up_debug_[layer] = upTS.epzpz();
+
+    pt_up_debug_[layer]   = upTS.pT();
+    phi_up_debug_[layer]  = upTS.momPhi();
+    eta_up_debug_[layer]  = upTS.momEta();
+    ept_up_debug_[layer]  = upTS.epT();
+    ephi_up_debug_[layer] = upTS.emomPhi();
+    eeta_up_debug_[layer] = upTS.emomEta();
+
+    invpt_up_debug_[layer]  = upTS.invpT();
+    einvpt_up_debug_[layer] = upTS.einvpT();
+    theta_up_debug_[layer]  = upTS.theta();
+    etheta_up_debug_[layer] = upTS.etheta();
+  }
+
+  // fill it once per track (i.e. once per track by definition)
+  debugtree_->Fill();
 }
 
 void TTreeValidation::fillSegmentTree(const BinInfoMap& segmentMap, int evtID){

--- a/Track.h
+++ b/Track.h
@@ -234,10 +234,7 @@ private:
 
 typedef std::vector<TrackExtra> TrackExtraVec;
 typedef std::vector<Track> TrackVec;
-// pointer to an object in a vector is a bad idea, if the vector has to
-// resize that invalidates the pointer...
-//typedef std::vector<const Track*> TrackRefVec;
 typedef std::vector<TrackState> TSVec;
 typedef std::vector<std::pair<int, TrackState> > TSLayerPairVec;
-
+typedef std::vector<std::pair<int, float> > FltLayerPairVec; // used exclusively for debugtree
 #endif

--- a/Validation.h
+++ b/Validation.h
@@ -10,6 +10,7 @@ public:
   virtual void alignTrackExtra(TrackVec&, TrackExtraVec&) {}
 
   virtual void resetValidationMaps() {}
+  virtual void resetDebugVectors() {}
   virtual void makeSimTkToRecoTksMaps(Event&) {}
   virtual void makeSeedTkToRecoTkMaps(Event&) {}
 
@@ -21,9 +22,14 @@ public:
   virtual void collectFitTkCFMapInfo(int, const TrackState&) {}
   virtual void collectFitTkTSLayerPairVecMapInfo(int, const TSLayerPairVec&) {}
 
+  virtual void collectPropTSLayerVecInfo(int, const TrackState&) {} // exclusively for debugtree
+  virtual void collectChi2LayerVecInfo(int, float) {} // exclusively for debugtree
+  virtual void collectUpTSLayerVecInfo(int, const TrackState&) {} // exclusively for debugtree
+
   virtual void fillSeedInfoTree(const TripletIdxVec&, const Event&) {}
   virtual void fillSeedTree(const TripletIdxVec&, const TripletIdxVec&, const Event&) {}
 
+  virtual void fillDebugTree(const Event&) {}
   virtual void fillSegmentTree(const BinInfoMap&, int) {}
   virtual void fillBranchTree(int) {}
   virtual void fillEfficiencyTree(const Event&) {}

--- a/buildtest.cc
+++ b/buildtest.cc
@@ -187,11 +187,13 @@ void extendCandidate(const Event& ev, const cand_t& cand, candvec& tmp_candidate
   dprint("processing candidate with nHits=" << tkcand.nFoundHits());
 #ifdef LINEARINTERP
   TrackState propState = propagateHelixToR(updatedState,ev.geom_.Radius(ilayer));
+  if (Config::super_debug) { ev.validation_.collectPropTSLayerVecInfo(ilayer,propState); }
 #else
 #ifdef TBB
 #error "Invalid combination of options (thread safety)"
 #endif
   TrackState propState = propagateHelixToLayer(updatedState,ilayer,ev.geom_);
+  if (Config::super_debug) { ev.validation_.collectPropTSLayerVecInfo(ilayer,propState); }
 #endif // LINEARINTERP
 #ifdef CHECKSTATEVALID
   if (!propState.valid) {
@@ -260,12 +262,14 @@ void extendCandidate(const Event& ev, const cand_t& cand, candvec& tmp_candidate
 #endif
       dprint(propState.position() - hitMeas.parameters());
       const float chi2 = computeChi2(propState,hitMeas);
+      if (Config::super_debug) { ev.validation_.collectChi2LayerVecInfo(ilayer,chi2); }
       dprint("found hit with index: " << cand_hit_idx << " from sim track " 
 	     << ev.simHitsInfo_[evt_lay_hits[ilayer][cand_hit_idx].mcHitID()].mcTrackID()
 	     << " chi2=" << chi2 << std::endl);
     
       if ((chi2<Config::chi2Cut)&&(chi2>0.)) {//fixme 
         const TrackState tmpUpdatedState = updateParameters(propState, hitMeas);
+	if (Config::super_debug) { ev.validation_.collectUpTSLayerVecInfo(ilayer,tmpUpdatedState); }
         Track tmpCand = tkcand.clone();
         tmpCand.addHitIdx(cand_hit_idx,chi2);
         tmpCand.setState(tmpUpdatedState);
@@ -275,7 +279,7 @@ void extendCandidate(const Event& ev, const cand_t& cand, candvec& tmp_candidate
     }//end of consider hits on layer loop
 
   //add also the candidate for no hit found
-  if (tkcand.nFoundHits()==ilayer) {//only if this is the first missing hit
+  if (tkcand.nFoundHits()==ilayer && !Config::super_debug) {//only if this is the first missing hit and also not in super debug mode
     dprint("adding candidate with no hit");
     Track tmpCand = tkcand.clone();
     tmpCand.addHitIdx(-1,0.0f);

--- a/main.cc
+++ b/main.cc
@@ -130,18 +130,21 @@ int main(int argc, char** argv)
     ev.Segment();            ticks[1] += delta(t0);
     ev.Seed();               ticks[2] += delta(t0);
     ev.Find();               ticks[3] += delta(t0);
-    ev.Fit();                ticks[4] += delta(t0);
+    if (!Config::super_debug) {ev.Fit();                ticks[4] += delta(t0);}
     ev.Validate(ev.evtID()); ticks[5] += delta(t0);
 #endif
-    std::cout << "sim: " << ev.simTracks_.size() << " seed: " << ev.seedTracks_.size() << " found: " << ev.candidateTracks_.size() << " fit: " << ev.fitTracks_.size() << std::endl;
-    tracks[0] += ev.simTracks_.size();
-    tracks[1] += ev.seedTracks_.size();
-    tracks[2] += ev.candidateTracks_.size();
-    tracks[3] += ev.fitTracks_.size();
-    std::cout << "Built tracks" << std::endl;
-    ev.PrintStats(ev.candidateTracks_, ev.candidateTracksExtra_);
-    std::cout << "Fit tracks" << std::endl;
-    ev.PrintStats(ev.fitTracks_, ev.fitTracksExtra_);
+
+    if (!Config::super_debug) {
+      std::cout << "sim: " << ev.simTracks_.size() << " seed: " << ev.seedTracks_.size() << " found: " << ev.candidateTracks_.size() << " fit: " << ev.fitTracks_.size() << std::endl;
+      tracks[0] += ev.simTracks_.size();
+      tracks[1] += ev.seedTracks_.size();
+      tracks[2] += ev.candidateTracks_.size();
+      tracks[3] += ev.fitTracks_.size();
+      std::cout << "Built tracks" << std::endl;
+      ev.PrintStats(ev.candidateTracks_, ev.candidateTracksExtra_);
+      std::cout << "Fit tracks" << std::endl;
+      ev.PrintStats(ev.fitTracks_, ev.fitTracksExtra_);
+    }
   }
 
   std::vector<double> time(ticks.size());

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -17,7 +17,6 @@ inline float predz(const float z0, const float r0, const float z2, const float r
 
 void buildSeedsByMC(const TrackVec& evt_sim_tracks, TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed_extras, Event& ev){
   bool debug(true);
-  bool cfseed(false); // use CF fit for initial estimate
 
   for (int itrack=0;itrack<evt_sim_tracks.size();++itrack) {
     const Track& trk = evt_sim_tracks[itrack];
@@ -25,7 +24,7 @@ void buildSeedsByMC(const TrackVec& evt_sim_tracks, TrackVec& evt_seed_tracks, T
     float sumchi2 = 0;
 
     TrackState updatedState;
-    if (cfseed) {
+    if (Config::cf_seeding) {
       conformalFit(ev.layerHits_[0][trk.getHitIdx(0)],ev.layerHits_[1][trk.getHitIdx(1)],ev.layerHits_[2][trk.getHitIdx(2)],trk.charge(),updatedState,false); 
     }
     else {

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -17,20 +17,29 @@ inline float predz(const float z0, const float r0, const float z2, const float r
 
 void buildSeedsByMC(const TrackVec& evt_sim_tracks, TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed_extras, Event& ev){
   bool debug(true);
-  
+  bool cfseed(false); // use CF fit for initial estimate
+
   for (int itrack=0;itrack<evt_sim_tracks.size();++itrack) {
     const Track& trk = evt_sim_tracks[itrack];
     int   seedhits[Config::nLayers];
-    float chi2 = 0;
-    TrackState updatedState = trk.state();
-    dprint("processing sim track # " << itrack << " par=" << trk.parameters());
+    float sumchi2 = 0;
 
+    TrackState updatedState;
+    if (cfseed) {
+      conformalFit(ev.layerHits_[0][trk.getHitIdx(0)],ev.layerHits_[1][trk.getHitIdx(1)],ev.layerHits_[2][trk.getHitIdx(2)],trk.charge(),updatedState,false); 
+    }
+    else {
+      updatedState = trk.state();
+    }
+
+    dprint("processing sim track # " << itrack << " par=" << trk.parameters());
     TSLayerPairVec updatedStates; // validation for position pulls
 
     for (auto ilayer=0;ilayer<Config::nlayers_per_seed;++ilayer) {//seeds have first three layers as seeds
       auto hitidx = trk.getHitIdx(ilayer);
       const Hit& seed_hit = ev.layerHits_[ilayer][hitidx];
       TrackState propState = propagateHelixToR(updatedState,seed_hit.r());
+      if (Config::super_debug) { ev.validation_.collectPropTSLayerVecInfo(ilayer,propState); }
 #ifdef CHECKSTATEVALID
       if (!propState.valid) {
 	std::cout << "Seeding failed to propagate to layer: " << ilayer << " for sim track: " << itrack << std::endl;
@@ -38,15 +47,18 @@ void buildSeedsByMC(const TrackVec& evt_sim_tracks, TrackVec& evt_seed_tracks, T
       }
 #endif
       const auto& measState = seed_hit.measurementState();
-      chi2 += computeChi2(propState,measState); //--> could use this to make the chi2
+      const float chi2 = computeChi2(propState,measState); 
+      //      sumchi2 += chi2; //--> could use this to make the chi2
+      if (Config::super_debug) { ev.validation_.collectChi2LayerVecInfo(ilayer,chi2); }
       updatedState = updateParameters(propState, measState);
+      if (Config::super_debug) { ev.validation_.collectUpTSLayerVecInfo(ilayer,updatedState); }
       seedhits[ilayer] = hitidx;
 
       updatedStates.push_back(std::make_pair(ilayer,updatedState)); // validation
     }
     ev.validation_.collectSeedTkTSLayerPairVecMapInfo(itrack,updatedStates); // use to collect position pull info
 
-    Track seed(updatedState,0.,itrack,Config::nlayers_per_seed,seedhits);//fixme chi2
+    Track seed(updatedState,0.,itrack,Config::nlayers_per_seed,seedhits);//fixme chi2 (could use sumchi2)
     dprint("created seed track # " << itrack << " par=" << seed.parameters());
     evt_seed_tracks.push_back(seed);
     evt_seed_extras.emplace_back(itrack); 
@@ -125,13 +137,17 @@ void buildSeedsByRZFirstRPhiSecond(TrackVec& evt_seed_tracks, TrackExtraVec& evt
     }
   }
 
-  ev.validation_.fillSeedInfoTree(hitTriplets,ev);
+  if (!Config::super_debug) {
+    ev.validation_.fillSeedInfoTree(hitTriplets,ev);
+  }
 
   TripletIdxVec filteredTriplets;
   filterHitTripletsByCircleParams(evt_lay_hits,hitTriplets,filteredTriplets);  
   //  filterHitTripletsByRZChi2(evt_lay_hits,hitTriplets,filteredTriplets); // filter based on RZ chi2 cut
 
-  ev.validation_.fillSeedTree(hitTriplets,filteredTriplets,ev);
+  if (!Config::super_debug) {
+    ev.validation_.fillSeedTree(hitTriplets,filteredTriplets,ev);
+  }
 
   // turn triplets into track seeds by performing CF + KF fit  
   // buildSeedsFromTriplets(evt_lay_hits,filteredTriplets,evt_seed_tracks,evt_seed_extras,ev); 
@@ -215,7 +231,9 @@ void buildSeedsByRoadTriplets(TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed
   filterHitTripletsBySecondLayerZResidual(evt_lay_hits,hitTriplets,filteredTriplets1); // filter based on residual of 2nd hit and line in R-Z for 1st, 3rd hit
   filterHitTripletsByCircleParams(evt_lay_hits,filteredTriplets1,filteredTriplets); // filter based on circle fit to three hits (d0 and curvature)
   //  filterHitTripletsByRZChi2(evt_lay_hits,hitTriplets,filteredTriplets); // filter based on RZ chi2 cut
-  ev.validation_.fillSeedTree(hitTriplets,filteredTriplets,ev);
+  if (!Config::super_debug) {
+    ev.validation_.fillSeedTree(hitTriplets,filteredTriplets,ev);
+  }
   buildSeedsFromTriplets(evt_lay_hits,filteredTriplets,evt_seed_tracks,evt_seed_extras,ev);
 }
 
@@ -437,14 +455,12 @@ void filterHitTripletsByRZChi2(const std::vector<HitVec>& evt_lay_hits, const Tr
 void buildSeedsFromTriplets(const std::vector<HitVec>& evt_lay_hits, const TripletIdxVec& filtered_triplets, 
 			    TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed_extras, Event& ev){
   // now perform kalman fit on seeds --> first need initial parameters --> get from Conformal fitter!
-  const bool fiterrs  = false; // use errors derived for seeding
-
   unsigned int seedID = 0;
   for(auto&& hit_triplet : filtered_triplets){
     int charge = getCharge(evt_lay_hits[0][hit_triplet[0]],evt_lay_hits[1][hit_triplet[1]],evt_lay_hits[2][hit_triplet[2]]);
 
     TrackState updatedState;
-    conformalFit(evt_lay_hits[0][hit_triplet[0]],evt_lay_hits[1][hit_triplet[1]],evt_lay_hits[2][hit_triplet[2]],charge,updatedState,fiterrs); 
+    conformalFit(evt_lay_hits[0][hit_triplet[0]],evt_lay_hits[1][hit_triplet[1]],evt_lay_hits[2][hit_triplet[2]],charge,updatedState,false); 
 
     // CF is bad at getting a good pT estimate, phi and theta are fine
     // "best case" config found in other studies is to set TS by hand:
@@ -456,25 +472,28 @@ void buildSeedsFromTriplets(const std::vector<HitVec>& evt_lay_hits, const Tripl
     ev.validation_.collectSeedTkCFMapInfo(seedID,updatedState);
 
     TSLayerPairVec updatedStates; // validation for position pulls
-    float chi2 = 0;
+    float sumchi2 = 0;
     for (auto ilayer=0;ilayer<Config::nlayers_per_seed;++ilayer) {
       const Hit& seed_hit = evt_lay_hits[ilayer][hit_triplet[ilayer]];
       TrackState propState = propagateHelixToR(updatedState,seed_hit.r());
+      if (Config::super_debug) { ev.validation_.collectPropTSLayerVecInfo(ilayer,propState); }
 #ifdef CHECKSTATEVALID
       if (!propState.valid) {
         break;
       }
 #endif
       MeasurementState measState = seed_hit.measurementState();
-      chi2 += computeChi2(propState,measState);// --> could use this to make the chi2
+      const float chi2 = computeChi2(propState,measState);
+      sumchi2 += chi2;// --> could use this to make the chi2
+      if (Config::super_debug) { ev.validation_.collectChi2LayerVecInfo(ilayer,chi2); } 
       updatedState = updateParameters(propState, measState);
-
+      if (Config::super_debug) { ev.validation_.collectUpTSLayerVecInfo(ilayer,updatedState); }
       updatedStates.push_back(std::make_pair(ilayer,updatedState)); // validation
     }
     ev.validation_.collectSeedTkTSLayerPairVecMapInfo(seedID,updatedStates); // use to collect position pull info
 
     int hitIndices[3] = {hit_triplet[0],hit_triplet[1],hit_triplet[2]};
-    Track seed(updatedState,chi2,seedID,Config::nlayers_per_seed,hitIndices);//fixme chi2
+    Track seed(updatedState,sumchi2,seedID,Config::nlayers_per_seed,hitIndices);//fixme chi2
     evt_seed_tracks.push_back(seed);
     evt_seed_extras.emplace_back(seedID);
     seedID++; // increment dummy counter for seedID


### PR DESCRIPTION
This commit is only for SMatrix.

This version allows a test of building in SMatrix to follow the propagation and update track states of single track events with no skipped layers.

This tool is enabled with a simple ifdef, which sets a bool in Config.h. This forces the code to compile everything, then only perform the other validation when true.

Closed previous PR by accident.  Sorry for the duplication.