### PR TITLE
Kalman filter calculations rework

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -18,4 +18,5 @@ namespace Config
   int   finderReportBestOutOfN = 1;
 
   bool  useCMSGeom = false;
+  bool  readCmsswSeeds = false;
 }

--- a/Config.h
+++ b/Config.h
@@ -79,8 +79,8 @@ namespace Config
   constexpr int Niter = 5;
   constexpr float Bfield = 3.8112;
   constexpr bool doIterative = true;
-  constexpr bool useSimpleJac = true;  
-  constexpr bool useCurvJac = false;
+  constexpr bool useSimpleJac = false;
+  constexpr bool useCurvJac   = false;
   constexpr bool useTrigApprox = true;
 
   // Config for Hit and BinInfoUtils
@@ -121,6 +121,7 @@ namespace Config
 #define MAX_HITS 10
 #endif
 
+  //fixme: these should not be constant and modified when nTracks is set from reading a file
   constexpr int maxHitsConsidered = 25;
   const     int maxHitsPerBunch   = std::max(100, nTracks * 12 / 10 / nEtaPart) + maxHitsConsidered;
 
@@ -140,6 +141,7 @@ namespace Config
   extern int    finderReportBestOutOfN;
 
   extern bool   useCMSGeom;
+  extern bool   readCmsswSeeds;
 
   const std::string inputFile = "cmssw.simtracks.SingleMu1GeV.10k.new.txt";
   //const std::string inputFile = "cmssw.simtracks.SingleMu10GeV.10k.new.txt";

--- a/Config.h
+++ b/Config.h
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <string> // won't compile on clang gcc for mac OS w/o this!
 
-#define PRINTOUTS_FOR_PLOTS
+//#define PRINTOUTS_FOR_PLOTS
 
 namespace Config
 {

--- a/Event.cc
+++ b/Event.cc
@@ -332,6 +332,7 @@ void Event::read_in(FILE *fp)
   fread(&nt, sizeof(int), 1, fp);
   simTracks_.resize(nt);
   fread(&simTracks_[0], sizeof(Track), nt, fp);
+  Config::nTracks = nt;
 
   int nl;
   fread(&nl, sizeof(int), 1, fp);
@@ -347,6 +348,14 @@ void Event::read_in(FILE *fp)
   fread(&nm, sizeof(int), 1, fp);
   simHitsInfo_.resize(nm);
   fread(&simHitsInfo_[0], sizeof(MCHitInfo), nm, fp);
+
+  if (Config::useCMSGeom) {
+    int ns;
+    fread(&ns, sizeof(int), 1, fp);
+    seedTracks_.resize(ns);
+    if (Config::readCmsswSeeds) fread(&seedTracks_[0], sizeof(Track), ns, fp);
+    else fseek(fp, sizeof(Track)*ns, SEEK_CUR);
+  }
 
   /*
   printf("read %i tracks\n",nt);

--- a/Event.cc
+++ b/Event.cc
@@ -351,11 +351,15 @@ void Event::read_in(FILE *fp)
   /*
   printf("read %i tracks\n",nt);
   for (int it = 0; it<nt; it++) {
-    printf("track with pT=%5.3f\n",simTracks_[it].pT());
+    printf("track with q=%i pT=%5.3f and nHits=%i\n",simTracks_[it].charge(),simTracks_[it].pT(),simTracks_[it].nTotalHits());
     for (int ih=0; ih<simTracks_[it].nTotalHits(); ++ih) {
-      printf("hit idx=%i\n", simTracks_[it].getHitIdx(ih));
+      if (simTracks_[it].getHitIdx(ih)>=0)
+	printf("hit #%i idx=%i pos r=%5.3f\n",ih,simTracks_[it].getHitIdx(ih),layerHits_[ih][simTracks_[it].getHitIdx(ih)].r());
+      else
+	printf("hit #%i idx=%i\n",ih,simTracks_[it].getHitIdx(ih));
     }
   }
+
   printf("read %i layers\n",nl);
   for (int il = 0; il<nl; il++) {
     printf("read %i hits in layer %i\n",layerHits_[il].size(),il);

--- a/Hit.h
+++ b/Hit.h
@@ -10,7 +10,7 @@
 // moved from config to here
 inline int getEtaBin(float eta)
 {
-  
+  if (std::isfinite(eta)==0) return -1;
   //in this case we are out of bounds
   //if (fabs(eta)>Config::fEtaDet) return -1;//remove this line, just return first or last bin
   

--- a/Hit.h
+++ b/Hit.h
@@ -25,6 +25,7 @@ inline int getEtaBin(float eta)
 
 inline int getEtaBinExtendedEdge(float eta)
 {
+  if (std::isfinite(eta)==0) return -1;
   //in this case we are out of bounds
   if (fabs(eta) > Config::fEtaDet + Config::lEtaPart) return -1;
   

--- a/KalmanUtils.h
+++ b/KalmanUtils.h
@@ -6,10 +6,34 @@
 
 //float computeChi2(const TrackState& propagatedState, const MeasurementState& measurementState);
 inline float computeChi2(const TrackState& propagatedState, const MeasurementState& measurementState) {
+  /*
   int invFail(0);
   const SMatrix33 resErr = measurementState.errors() + propagatedState.errors.Sub<SMatrix33>(0,0);
   return ROOT::Math::Similarity(measurementState.parameters()-propagatedState.parameters.Sub<SVector3>(0),
                                 resErr.InverseFast(invFail));
+  */
+  float r = getHypot(measurementState.pos_[0],measurementState.pos_[1]);
+  //rotate to the tangent plane to the cylinder of radius r at the hit position
+  SMatrix33 rot;
+  rot[0][0] = -measurementState.pos_[1]/r;
+  rot[0][1] = 0;
+  rot[0][2] = measurementState.pos_[0]/r;
+  rot[1][0] = rot[0][2];
+  rot[1][1] = 0;
+  rot[1][2] = -rot[0][0];
+  rot[2][0] = 0;
+  rot[2][1] = 1;
+  rot[2][2] = 0;
+  const SMatrix33 rotT = ROOT::Math::Transpose(rot);
+  const SVector3 res_glo = measurementState.parameters()-propagatedState.parameters.Sub<SVector3>(0);
+  const SVector3 res_loc3 = rotT * res_glo;
+  //the matrix to invert has to be 2x2
+  const SVector2 res(res_loc3[0],res_loc3[1]);
+  const SMatrixSym33 resErr_glo = measurementState.errors() + propagatedState.errors.Sub<SMatrixSym33>(0,0);
+  const SMatrixSym22 resErr = ROOT::Math::SimilarityT(rot,resErr_glo).Sub<SMatrixSym22>(0,0);
+  int invFail(0);
+  SMatrixSym22 resErrInv = resErr.InverseFast(invFail);
+  return ROOT::Math::Similarity(res,resErrInv);
 }
 
 //see e.g. http://inspirehep.net/record/259509?ln=en

--- a/KalmanUtils.h
+++ b/KalmanUtils.h
@@ -4,37 +4,7 @@
 #include "Track.h"
 #include "Matrix.h"
 
-//float computeChi2(const TrackState& propagatedState, const MeasurementState& measurementState);
-inline float computeChi2(const TrackState& propagatedState, const MeasurementState& measurementState) {
-  /*
-  int invFail(0);
-  const SMatrix33 resErr = measurementState.errors() + propagatedState.errors.Sub<SMatrix33>(0,0);
-  return ROOT::Math::Similarity(measurementState.parameters()-propagatedState.parameters.Sub<SVector3>(0),
-                                resErr.InverseFast(invFail));
-  */
-  float r = getHypot(measurementState.pos_[0],measurementState.pos_[1]);
-  //rotate to the tangent plane to the cylinder of radius r at the hit position
-  SMatrix33 rot;
-  rot[0][0] = -measurementState.pos_[1]/r;
-  rot[0][1] = 0;
-  rot[0][2] = measurementState.pos_[0]/r;
-  rot[1][0] = rot[0][2];
-  rot[1][1] = 0;
-  rot[1][2] = -rot[0][0];
-  rot[2][0] = 0;
-  rot[2][1] = 1;
-  rot[2][2] = 0;
-  const SMatrix33 rotT = ROOT::Math::Transpose(rot);
-  const SVector3 res_glo = measurementState.parameters()-propagatedState.parameters.Sub<SVector3>(0);
-  const SVector3 res_loc3 = rotT * res_glo;
-  //the matrix to invert has to be 2x2
-  const SVector2 res(res_loc3[0],res_loc3[1]);
-  const SMatrixSym33 resErr_glo = measurementState.errors() + propagatedState.errors.Sub<SMatrixSym33>(0,0);
-  const SMatrixSym22 resErr = ROOT::Math::SimilarityT(rot,resErr_glo).Sub<SMatrixSym22>(0,0);
-  int invFail(0);
-  SMatrixSym22 resErrInv = resErr.InverseFast(invFail);
-  return ROOT::Math::Similarity(res,resErrInv);
-}
+float computeChi2(const TrackState& propagatedState, const MeasurementState& measurementState);
 
 //see e.g. http://inspirehep.net/record/259509?ln=en
 void updateParameters66(TrackState& propagatedState, MeasurementState& measurementState, TrackState& result);

--- a/Math/MatrixRepresentationsStatic.h
+++ b/Math/MatrixRepresentationsStatic.h
@@ -1,44 +1,49 @@
 // @(#)root/smatrix:$Id$
-// Author: L. Moneta, J. Palacios    2006  
+// Author: L. Moneta, J. Palacios    2006
 
 #ifndef ROOT_Math_MatrixRepresentationsStatic
 #define ROOT_Math_MatrixRepresentationsStatic 1
 
 // Include files
 
-/** 
-    @defgroup MatRep SMatrix Storage Representation 
+/**
+    @defgroup MatRep SMatrix Storage Representation
     @ingroup SMatrixGroup
- 
+
     @author Juan Palacios
     @date   2006-01-15
- 
+
     Classes MatRepStd and MatRepSym for generic and symmetric matrix
     data storage and manipulation. Define data storage and access, plus
     operators =, +=, -=, ==.
- 
+
  */
 
 #ifndef ROOT_Math_StaticCheck
 #include "Math/StaticCheck.h"
 #endif
 
+#include <cstddef>
+#include <utility>
+#include <type_traits>
+#include <array>
+
 namespace ROOT {
-   
+
 namespace Math {
 
-   //________________________________________________________________________________    
+   //________________________________________________________________________________
    /**
       MatRepStd
-      Standard Matrix representation for a general D1 x D2 matrix. 
+      Standard Matrix representation for a general D1 x D2 matrix.
       This class is itself a template on the contained type T, the number of rows and the number of columns.
-      Its data member is an array T[nrows*ncols] containing the matrix data. 
-      The data are stored in the row-major C convention. 
-      For example, for a matrix, M, of size 3x3, the data \f$ \left[a_0,a_1,a_2,.......,a_7,a_8 \right] \f$d are stored in the following order: 
+      Its data member is an array T[nrows*ncols] containing the matrix data.
+      The data are stored in the row-major C convention.
+      For example, for a matrix, M, of size 3x3, the data \f$ \left[a_0,a_1,a_2,.......,a_7,a_8 \right] \f$d are stored in the following order:
       \f[
-      M = \left( \begin{array}{ccc} 
-      a_0 & a_1 & a_2  \\ 
-      a_3 & a_4  & a_5  \\ 
+      M = \left( \begin{array}{ccc}
+      a_0 & a_1 & a_2  \\
+      a_3 & a_4  & a_5  \\
       a_6 & a_7  & a_8   \end{array} \right)
       \f]
 
@@ -49,7 +54,7 @@ namespace Math {
    template <class T, unsigned int D1, unsigned int D2=D1>
    class MatRepStd {
 
-   public: 
+   public:
 
       typedef T  value_type;
 
@@ -65,9 +70,9 @@ namespace Math {
 
       inline T apply(unsigned int i) const { return fArray[i]; }
 
-      inline T* Array() { return fArray; }  
+      inline T* Array() { return fArray; }
 
-      inline const T* Array() const { return fArray; }  
+      inline const T* Array() const { return fArray; }
 
       template <class R>
       inline MatRepStd<T, D1, D2>& operator+=(const R& rhs) {
@@ -87,7 +92,7 @@ namespace Math {
          return *this;
       }
 
-      template <class R> 
+      template <class R>
       inline bool operator==(const R& rhs) const {
          bool rc = true;
          for(unsigned int i=0; i<kSize; ++i) {
@@ -104,22 +109,22 @@ namespace Math {
          /// return no of elements: rows*columns
          kSize = D1*D2
       };
-      
+
    private:
       //T __attribute__ ((aligned (16))) fArray[kSize];
       T  fArray[kSize];
    };
-    
-    
+
+
 //     template<unigned int D>
-//     struct Creator { 
+//     struct Creator {
 //       static const RowOffsets<D> & Offsets() {
-// 	static RowOffsets<D> off;
-// 	return off;
+//          static RowOffsets<D> off;
+//           return off;
 //       }
 
    /**
-      Static structure to keep the conversion from (i,j) to offsets in the storage data for a 
+      Static structure to keep the conversion from (i,j) to offsets in the storage data for a
       symmetric matrix
    */
 
@@ -130,9 +135,9 @@ namespace Math {
          v[0]=0;
          for (unsigned int i=1; i<D; ++i)
             v[i]=v[i-1]+i;
-         for (unsigned int i=0; i<D; ++i) { 
+         for (unsigned int i=0; i<D; ++i) {
             for (unsigned int j=0; j<=i; ++j)
-               fOff[i*D+j] = v[i]+j; 
+               fOff[i*D+j] = v[i]+j;
             for (unsigned int j=i+1; j<D; ++j)
                fOff[i*D+j] = v[j]+i ;
          }
@@ -142,150 +147,100 @@ namespace Math {
       int fOff[D*D];
    };
 
-// Make the lookup tables available at compile time:
-// Add them to a namespace?
-static const int fOff1x1[] = {0};
-static const int fOff2x2[] = {0, 1, 1, 2};
-static const int fOff3x3[] = {0, 1, 3, 1, 2, 4, 3, 4, 5};
-static const int fOff4x4[] = {0, 1, 3, 6, 1, 2, 4, 7, 3, 4, 5, 8, 6, 7, 8, 9};
-static const int fOff5x5[] = {0, 1, 3, 6, 10, 1, 2, 4, 7, 11, 3, 4, 5, 8, 12, 6, 7, 8, 9, 13, 10, 11, 12, 13, 14};
-static const int fOff6x6[] = {0, 1, 3, 6, 10, 15, 1, 2, 4, 7, 11, 16, 3, 4, 5, 8, 12, 17, 6, 7, 8, 9, 13, 18, 10, 11, 12, 13, 14, 19, 15, 16, 17, 18, 19, 20};
+  namespace rowOffsetsUtils {
 
-static const int fOff7x7[] = {0, 1, 3, 6, 10, 15, 21, 1, 2, 4, 7, 11, 16, 22, 3, 4, 5, 8, 12, 17, 23, 6, 7, 8, 9, 13, 18, 24, 10, 11, 12, 13, 14, 19, 25, 15, 16, 17, 18, 19, 20, 26, 21, 22, 23, 24, 25, 26, 27};
+    ///////////
+    // Some meta template stuff
+    template<int...> struct indices{};
 
-static const int fOff8x8[] = {0, 1, 3, 6, 10, 15, 21, 28, 1, 2, 4, 7, 11, 16, 22, 29, 3, 4, 5, 8, 12, 17, 23, 30, 6, 7, 8, 9, 13, 18, 24, 31, 10, 11, 12, 13, 14, 19, 25, 32, 15, 16, 17, 18, 19, 20, 26, 33, 21, 22, 23, 24, 25, 26, 27, 34, 28, 29, 30, 31, 32, 33, 34, 35};
+    template<int I, class IndexTuple, int N>
+    struct make_indices_impl;
 
-static const int fOff9x9[] = {0, 1, 3, 6, 10, 15, 21, 28, 36, 1, 2, 4, 7, 11, 16, 22, 29, 37, 3, 4, 5, 8, 12, 17, 23, 30, 38, 6, 7, 8, 9, 13, 18, 24, 31, 39, 10, 11, 12, 13, 14, 19, 25, 32, 40, 15, 16, 17, 18, 19, 20, 26, 33, 41, 21, 22, 23, 24, 25, 26, 27, 34, 42, 28, 29, 30, 31, 32, 33, 34, 35, 43, 36, 37, 38, 39, 40, 41, 42, 43, 44};
+    template<int I, int... Indices, int N>
+    struct make_indices_impl<I, indices<Indices...>, N>
+    {
+      typedef typename make_indices_impl<I + 1, indices<Indices..., I>,
+					 N>::type type;
+    };
 
-static const int fOff10x10[] = {0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 1, 2, 4, 7, 11, 16, 22, 29, 37, 46, 3, 4, 5, 8, 12, 17, 23, 30, 38, 47, 6, 7, 8, 9, 13, 18, 24, 31, 39, 48, 10, 11, 12, 13, 14, 19, 25, 32, 40, 49, 15, 16, 17, 18, 19, 20, 26, 33, 41, 50, 21, 22, 23, 24, 25, 26, 27, 34, 42, 51, 28, 29, 30, 31, 32, 33, 34, 35, 43, 52, 36, 37, 38, 39, 40, 41, 42, 43, 44, 53, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54};
+    template<int N, int... Indices>
+    struct make_indices_impl<N, indices<Indices...>, N> {
+      typedef indices<Indices...> type;
+    };
 
-template<>
-	struct RowOffsets<1> {
-	  RowOffsets() {}
-	  int operator()(unsigned int , unsigned int ) const { return 0; } // Just one element
-	  int apply(unsigned int ) const { return 0; }
-	};
+    template<int N>
+    struct make_indices : make_indices_impl<0, indices<>, N> {};
+    // end of stuff
 
-template<>
-	struct RowOffsets<2> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return i+j; /*fOff2x2[i*2+j];*/ }
-	  int apply(unsigned int i) const { return fOff2x2[i]; }
-	};
 
-template<>
-	struct RowOffsets<3> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff3x3[i*3+j]; }
-	  int apply(unsigned int i) const { return fOff3x3[i]; }
-	};
 
-template<>
-	struct RowOffsets<4> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff4x4[i*4+j]; }
-	  int apply(unsigned int i) const { return fOff4x4[i]; }
-	};
+    template<int I0, class F, int... I>
+    constexpr std::array<decltype(std::declval<F>()(std::declval<int>())), sizeof...(I)>
+    do_make(F f, indices<I...>)
+    {
+      return  std::array<decltype(std::declval<F>()(std::declval<int>())),
+			 sizeof...(I)>{{ f(I0 + I)... }};
+    }
 
-	template<>
-	struct RowOffsets<5> {
-	  inline RowOffsets() {}
-	  inline int operator()(unsigned int i, unsigned int j) const { return fOff5x5[i*5+j]; }
-//	int operator()(unsigned int i, unsigned int j) const {
-//	  if(j <= i) return (i * (i + 1)) / 2 + j;
-//		else return (j * (j + 1)) / 2 + i;
-//	  }  
-	inline int apply(unsigned int i) const { return fOff5x5[i]; }
-	};
+    template<int N, int I0 = 0, class F>
+    constexpr std::array<decltype(std::declval<F>()(std::declval<int>())), N>
+    make(F f) {
+      return do_make<I0>(f, typename make_indices<N>::type());
+    }
 
-template<>
-	struct RowOffsets<6> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff6x6[i*6+j]; }
-	  int apply(unsigned int i) const { return fOff6x6[i]; }
-	};
+  } // namespace rowOffsetsUtils
 
-template<>
-	struct RowOffsets<7> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff7x7[i*7+j]; }
-	  int apply(unsigned int i) const { return fOff7x7[i]; }
-	};
-
-template<>
-	struct RowOffsets<8> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff8x8[i*8+j]; }
-	  int apply(unsigned int i) const { return fOff8x8[i]; }
-	};
-
-template<>
-	struct RowOffsets<9> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff9x9[i*9+j]; }
-	  int apply(unsigned int i) const { return fOff9x9[i]; }
-	};
-
-template<>
-	struct RowOffsets<10> {
-	  RowOffsets() {}
-	  int operator()(unsigned int i, unsigned int j) const { return fOff10x10[i*10+j]; }
-	  int apply(unsigned int i) const { return fOff10x10[i]; }
-	};
 
 //_________________________________________________________________________________
    /**
       MatRepSym
       Matrix storage representation for a symmetric matrix of dimension NxN
-      This class is a template on the contained type and on the symmetric matrix size, N. 
-      It has as data member an array of type T of size N*(N+1)/2, 
+      This class is a template on the contained type and on the symmetric matrix size, N.
+      It has as data member an array of type T of size N*(N+1)/2,
       containing the lower diagonal block of the matrix.
-      The order follows the lower diagonal block, still in a row-major convention. 
-      For example for a symmetric 3x3 matrix the order of the 6 elements 
-      \f$ \left[a_0,a_1.....a_5 \right]\f$ is: 
+      The order follows the lower diagonal block, still in a row-major convention.
+      For example for a symmetric 3x3 matrix the order of the 6 elements
+      \f$ \left[a_0,a_1.....a_5 \right]\f$ is:
       \f[
-      M = \left( \begin{array}{ccc} 
-      a_0 & a_1  & a_3  \\ 
+      M = \left( \begin{array}{ccc}
+      a_0 & a_1  & a_3  \\
       a_1 & a_2  & a_4  \\
       a_3 & a_4 & a_5   \end{array} \right)
       \f]
 
-      @ingroup MatRep 
+      @ingroup MatRep
    */
    template <class T, unsigned int D>
    class MatRepSym {
 
-   public: 
+   public:
 
-      MatRepSym() :fOff(0) { CreateOffsets(); } 
+    /* constexpr */ inline MatRepSym(){}
 
-      typedef T  value_type;
+    typedef T  value_type;
 
-      inline const T& operator()(unsigned int i, unsigned int j) const {
-         return fArray[Offsets()(i,j)];
-      }
-      inline T& operator()(unsigned int i, unsigned int j) {
-         return fArray[Offsets()(i,j)];
-      }
 
-      inline T& operator[](unsigned int i) { 
-         return fArray[Offsets().apply(i) ];
-//return fArray[Offsets()(i/D, i%D)];
-      }
+    inline T & operator()(unsigned int i, unsigned int j)
+     { return fArray[offset(i, j)]; }
 
-      inline const T& operator[](unsigned int i) const {
-         return fArray[Offsets().apply(i) ];
-//return fArray[Offsets()(i/D, i%D)];
-      }
+     inline /* constexpr */ T const & operator()(unsigned int i, unsigned int j) const
+     { return fArray[offset(i, j)]; }
 
-      inline T apply(unsigned int i) const {
-         return fArray[Offsets().apply(i) ];
-         //return operator()(i/D, i%D);
-      }
+     inline T& operator[](unsigned int i) {
+       return fArray[off(i)];
+     }
 
-      inline T* Array() { return fArray; }  
+     inline /* constexpr */ T const & operator[](unsigned int i) const {
+       return fArray[off(i)];
+     }
 
-      inline const T* Array() const { return fArray; }  
+     inline /* constexpr */ T apply(unsigned int i) const {
+       return fArray[off(i)];
+     }
+
+     inline T* Array() { return fArray; }
+
+     inline const T* Array() const { return fArray; }
 
       /**
          assignment : only symmetric to symmetric allowed
@@ -328,7 +283,7 @@ template<>
          for(unsigned int i=0; i<kSize; ++i) fArray[i] -= rhs.Array()[i];
          return *this;
       }
-      template <class R> 
+      template <class R>
       inline bool operator==(const R& rhs) const {
          bool rc = true;
          for(unsigned int i=0; i<D*D; ++i) {
@@ -336,7 +291,7 @@ template<>
          }
          return rc;
       }
-      
+
       enum {
          /// return no. of matrix rows
          kRows = D,
@@ -346,26 +301,30 @@ template<>
          kSize = D*(D+1)/2
       };
 
-      
-      void CreateOffsets() {
-         const static RowOffsets<D> off;
-         fOff = &off;
-      }
-      
-      inline const RowOffsets<D> & Offsets() const {
-         return *fOff;
-      }
+     static constexpr int off0(int i) { return i==0 ? 0 : off0(i-1)+i;}
+     static constexpr int off2(int i, int j) { return j<i ? off0(i)+j : off0(j)+i; }
+     static constexpr int off1(int i) { return off2(i/D, i%D);}
+
+     static int off(int i) {
+       static constexpr auto v = rowOffsetsUtils::make<D*D>(off1);
+       return v[i];
+     }
+
+     static inline constexpr unsigned int
+     offset(unsigned int i, unsigned int j)
+     {
+       //if (j > i) std::swap(i, j);
+       return off(i*D+j);
+       // return (i>j) ? (i * (i+1) / 2) + j :  (j * (j+1) / 2) + i;
+     }
 
    private:
       //T __attribute__ ((aligned (16))) fArray[kSize];
       T fArray[kSize];
-
-      const RowOffsets<D> * fOff;   //! transient
-
    };
 
 
- 
+
 } // namespace Math
 } // namespace ROOT
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -12,6 +12,10 @@ typedef ROOT::Math::SMatrix<float,3> SMatrix33;
 typedef ROOT::Math::SMatrix<float,3,3,ROOT::Math::MatRepSym<float,3> >    SMatrixSym33;
 typedef ROOT::Math::SVector<float,3> SVector3;
 
+typedef ROOT::Math::SMatrix<float,2> SMatrix22;
+typedef ROOT::Math::SMatrix<float,2,2,ROOT::Math::MatRepSym<float,2> >    SMatrixSym22;
+typedef ROOT::Math::SVector<float,2> SVector2;
+
 typedef ROOT::Math::SMatrix<float,3,6> SMatrix36;
 typedef ROOT::Math::SMatrix<float,6,3> SMatrix63;
 
@@ -88,7 +92,12 @@ inline void sincos4(float x, float& sin, float& cos)
   typedef Matriplex::Matriplex<float, HH,  1, NN>   MPlexHV;
   typedef Matriplex::MatriplexSym<float, HH,  NN>   MPlexHS;
 
+  typedef Matriplex::Matriplex<float, 2,  2, NN>    MPlex22;
+  typedef Matriplex::Matriplex<float, 2,  1, NN>    MPlex2V;
+  typedef Matriplex::MatriplexSym<float,  2, NN>    MPlex2S;
+
   typedef Matriplex::Matriplex<float, LL, HH, NN>   MPlexLH;
+  typedef Matriplex::Matriplex<float, HH, LL, NN>   MPlexHL;
 
   typedef Matriplex::Matriplex<float, 1, 1, NN>     MPlexQF;
   typedef Matriplex::Matriplex<int,   1, 1, NN>     MPlexQI;

--- a/Track.cc
+++ b/Track.cc
@@ -4,6 +4,9 @@
 // find the simtrack that provided the most hits
 void TrackExtra::setMCTrackIDInfo(const Track& trk, const std::vector<HitVec>& layerHits, const MCHitInfoVec& globalHitInfo)
 {
+#ifdef DEBUG
+  const bool debug = g_dump;
+#endif
   std::vector<int> mctrack;
   auto hitIdx = trk.nTotalHits();
   for (int ihit = 0; ihit < hitIdx; ++ihit){

--- a/Track.h
+++ b/Track.h
@@ -39,6 +39,7 @@ public:
   float py()     const {return parameters.At(4);}
   float pz()     const {return parameters.At(5);}
   float pT()     const {return sqrtf(getRad2(px(),py()));}
+  float p()      const {return sqrtf(px()*px()+py()*py()+pz()*pz());}
   float momPhi() const {return       getPhi (px(),py());}
   float momEta() const {return       getEta (pT(),pz());}
 

--- a/benchmark-fit.sh
+++ b/benchmark-fit.sh
@@ -1,14 +1,16 @@
 #! /bin/bash
 
-sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 1000000/g' Config.h 
+sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 1000000/g' Config.cc
 
 make clean
 make -j 8
 
+./mkFit/mkFit --write --file-name simtracks_10x1M.bin
+
 for nth in 1 3 7 21
 do
 echo nth=${nth}
-./mkFit/mkFit --fit-std-only --num-thr ${nth} >& log_host_10x1M_FIT_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name simtracks_10x1M.bin --fit-std-only --num-thr ${nth} >& log_host_10x1M_FIT_NVU8int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -18,12 +20,12 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-./mkFit/mkFit --fit-std-only --num-thr 1 >& log_host_10x1M_FIT_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name simtracks_10x1M.bin --fit-std-only --num-thr 1 >& log_host_10x1M_FIT_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config
 
-sed -i 's/constexpr int nTracks = 1000000/constexpr int nTracks = 20000/g' Config.h 
+sed -i 's/constexpr int nTracks = 1000000/constexpr int nTracks = 20000/g' Config.cc
 
 make clean
 make -j 8

--- a/benchmark-fit.sh
+++ b/benchmark-fit.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 1000000/g' Config.cc
+sed -i 's/int nTracks = 20000/int nTracks = 1000000/g' Config.cc
 
 make clean
 make -j 8
@@ -25,7 +25,7 @@ sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config
 
-sed -i 's/constexpr int nTracks = 1000000/constexpr int nTracks = 20000/g' Config.cc
+sed -i 's/int nTracks = 1000000/int nTracks = 20000/g' Config.cc
 
 make clean
 make -j 8

--- a/benchmark-mic-fit.sh
+++ b/benchmark-mic-fit.sh
@@ -1,13 +1,17 @@
 #! /bin/bash
 
-sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 500000/g' Config.h 
+sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 500000/g' Config.cc 
 
 make clean
 make -j 8
+
+./mkFit/mkFit --write --file-name simtracks_10x500k.bin
+scp simtracks_10x500k.bin mic0:
+
 for nth in 1 3 7 21 42 63 84 105 126 147 168 189 210
 do
 echo nth=${nth}
-ssh mic0 ./mkFit-mic --fit-std-only --num-thr ${nth} >& log_mic_10x500k_FIT_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x500k.bin --fit-std-only --num-thr ${nth} >& log_mic_10x500k_FIT_NVU16int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -17,12 +21,12 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-ssh mic0 ./mkFit-mic --fit-std-only --num-thr 1 >& log_mic_10x500k_FIT_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x500k.bin --fit-std-only --num-thr 1 >& log_mic_10x500k_FIT_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config
 
-sed -i 's/constexpr int nTracks = 500000/constexpr int nTracks = 20000/g' Config.h 
+sed -i 's/constexpr int nTracks = 500000/constexpr int nTracks = 20000/g' Config.cc 
 
 make clean
 make -j 8

--- a/benchmark-mic-fit.sh
+++ b/benchmark-mic-fit.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-sed -i 's/constexpr int nTracks = 20000/constexpr int nTracks = 500000/g' Config.cc 
+sed -i 's/int nTracks = 20000/int nTracks = 500000/g' Config.cc 
 
 make clean
 make -j 8
@@ -26,7 +26,7 @@ sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config
 
-sed -i 's/constexpr int nTracks = 500000/constexpr int nTracks = 20000/g' Config.cc 
+sed -i 's/int nTracks = 500000/int nTracks = 20000/g' Config.cc 
 
 make clean
 make -j 8

--- a/benchmark-mic.sh
+++ b/benchmark-mic.sh
@@ -5,13 +5,16 @@ sed -i 's/\/\/\#define PRINTOUTS_FOR_PLOTS/\#define PRINTOUTS_FOR_PLOTS/g' Confi
 make clean
 make -j 8
 
+./mkFit/mkFit --write --file-name simtracks_10x20k.bin
+scp simtracks_10x20k.bin mic0:
+
 for nth in 1 3 7 21 42 63 84 105 126 147 168 189 210
 do
 echo nth=${nth}
-ssh mic0 ./mkFit-mic --build-bh  --num-thr ${nth} >& log_mic_10x20k_BH_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --build-std --num-thr ${nth} >& log_mic_10x20k_ST_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --build-ce  --num-thr ${nth} >& log_mic_10x20k_CE_NVU16int_NTH${nth}.txt
-ssh mic0 ./mkFit-mic --build-ce  --num-thr ${nth} --cloner-single-thread >& log_mic_10x20k_CEST_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_mic_10x20k_BH_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_mic_10x20k_ST_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_mic_10x20k_CE_NVU16int_NTH${nth}.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_mic_10x20k_CEST_NVU16int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -21,10 +24,10 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-ssh mic0 ./mkFit-mic --build-bh  --num-thr 1 >& log_mic_10x20k_BH_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --build-std --num-thr 1 >& log_mic_10x20k_ST_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --build-ce  --num-thr 1 >& log_mic_10x20k_CE_NVU${nvu}_NTH1.txt
-ssh mic0 ./mkFit-mic --build-ce  --num-thr 1 --cloner-single-thread >& log_mic_10x20k_CEST_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_mic_10x20k_BH_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-std --num-thr 1 >& log_mic_10x20k_ST_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_mic_10x20k_CE_NVU${nvu}_NTH1.txt
+ssh mic0 ./mkFit-mic --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_mic_10x20k_CEST_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -5,13 +5,15 @@ sed -i 's/\/\/\#define PRINTOUTS_FOR_PLOTS/\#define PRINTOUTS_FOR_PLOTS/g' Confi
 make clean
 make -j 8
 
+./mkFit/mkFit --write --file-name simtracks_10x20k.bin
+
 for nth in 1 3 7 21
 do
 echo nth=${nth}
-./mkFit/mkFit --build-bh  --num-thr ${nth} >& log_host_10x20k_BH_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --build-std --num-thr ${nth} >& log_host_10x20k_ST_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --build-ce  --num-thr ${nth} >& log_host_10x20k_CE_NVU8int_NTH${nth}.txt
-./mkFit/mkFit --build-ce  --num-thr ${nth} --cloner-single-thread >& log_host_10x20k_CEST_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_host_10x20k_BH_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-std --num-thr ${nth} >& log_host_10x20k_ST_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} >& log_host_10x20k_CE_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr ${nth} --cloner-single-thread >& log_host_10x20k_CEST_NVU8int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config
@@ -21,10 +23,10 @@ sed -i "s/MPT_SIZE=XX/MPT_SIZE=${nvu}/g" Makefile.config
 make clean
 make -j 8
 echo nvu=${nvu}
-./mkFit/mkFit --build-bh  --num-thr 1 >& log_host_10x20k_BH_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --build-std --num-thr 1 >& log_host_10x20k_ST_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --build-ce  --num-thr 1 >& log_host_10x20k_CE_NVU${nvu}_NTH1.txt
-./mkFit/mkFit --build-ce  --num-thr 1 --cloner-single-thread >& log_host_10x20k_CEST_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-bh  --num-thr 1 >& log_host_10x20k_BH_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-std --num-thr 1 >& log_host_10x20k_ST_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 >& log_host_10x20k_CE_NVU${nvu}_NTH1.txt
+./mkFit/mkFit --read --file-name simtracks_10x20k.bin --build-ce  --num-thr 1 --cloner-single-thread >& log_host_10x20k_CEST_NVU${nvu}_NTH1.txt
 sed -i "s/MPT_SIZE=${nvu}/MPT_SIZE=XX/g" Makefile.config
 done
 sed -i 's/USE_INTRINSICS := -DMPT_SIZE=XX/# USE_INTRINSICS := -DMPT_SIZE=1/g' Makefile.config

--- a/makeBenchmarkPlotsFit.C
+++ b/makeBenchmarkPlotsFit.C
@@ -1,6 +1,6 @@
 {
 
-  bool isMic = true;
+  bool isMic = false;
   
   TString hORm = "host";
   if (isMic) hORm = "mic";

--- a/mkFit/GenMPlexOps.pl
+++ b/mkFit/GenMPlexOps.pl
@@ -5,13 +5,197 @@ use lib "../Matriplex";
 use GenMul;
 use warnings;
 
-my $DIM = 6;
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- propagated errors in "polar" coordinates
+# propErr_pol = jac_pol * propErr * jac_polT
+
+$jac_pol = new GenMul::Matrix('name'=>'a', 'M'=>6, 'N'=>6);
+$jac_pol->set_pattern(<<"FNORD");
+1 0 0 0 0 0
+0 1 0 0 0 0
+0 0 1 0 0 0
+0 0 0 x x 0
+0 0 0 x x 0
+0 0 0 x x x
+FNORD
+
+$propErr = new GenMul::MatrixSym('name'=>'b', 'M'=>6, 'N'=>6);
+
+$temp   = new GenMul::Matrix('name'=>'c', 'M'=>6, 'N'=>6);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("PolarErr.ah",
+                                    $jac_pol, $propErr, $temp);
+
+$jac_polT = new GenMul::MatrixTranspose($jac_pol);
+$propErr_pol = new GenMul::MatrixSym('name'=>'c', 'M'=>6, 'N'=>6);
+$temp  ->{name} = 'b';
+
+$m->dump_multiply_std_and_intrinsic("PolarErrTransp.ah",
+                                    $temp, $jac_polT, $propErr_pol);
+
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- updated errors in cartesian coordinates
+# outErr = jac_back_pol * outErr_pol * jac_back_polT
+
+$jac_back_pol = new GenMul::Matrix('name'=>'a', 'M'=>6, 'N'=>6);
+$jac_back_pol->set_pattern(<<"FNORD");
+1 0 0 0 0 0
+0 1 0 0 0 0
+0 0 1 0 0 0
+0 0 0 x x 0
+0 0 0 x x 0
+0 0 0 x 0 x
+FNORD
+
+$outErr_pol = new GenMul::MatrixSym('name'=>'b', 'M'=>6, 'N'=>6);
+
+$temp   = new GenMul::Matrix('name'=>'c', 'M'=>6, 'N'=>6);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("CartesianErr.ah",
+                                    $jac_back_pol, $outErr_pol, $temp);
+
+$jac_back_polT = new GenMul::MatrixTranspose($jac_back_pol);
+$outErr = new GenMul::MatrixSym('name'=>'c', 'M'=>6, 'N'=>6);
+$temp  ->{name} = 'b';
+
+$m->dump_multiply_std_and_intrinsic("CartesianErrTransp.ah",
+                                    $temp, $jac_back_polT, $outErr);
+
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- first term to get kalman gain (H^T*G)
+# temp = rot * resErr_loc
+
+$rot = new GenMul::Matrix('name'=>'a', 'M'=>3, 'N'=>3);
+$rot->set_pattern(<<"FNORD");
+x 0 x
+x 0 x
+0 1 0
+FNORD
+
+$resErr_loc = new GenMul::MatrixSym('name'=>'b', 'M'=>3, 'N'=>3);
+
+$temp   = new GenMul::Matrix('name'=>'c', 'M'=>3, 'N'=>3);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("KalmanHTG.ah",
+                                    $rot, $resErr_loc, $temp);
+
+
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- kalman gain
+# K = propErr_pol * resErrTmpLH
+
+$propErr_pol = new GenMul::MatrixSym('name'=>'a', 'M'=>6, 'N'=>6);
+
+$resErrTmpLH  = new GenMul::Matrix('name'=>'b', 'M'=>6, 'N'=>3);
+$resErrTmpLH->set_pattern(<<"FNORD");
+x x 0
+x x 0
+x x 0
+0 0 0
+0 0 0
+0 0 0
+FNORD
+
+$K   = new GenMul::Matrix('name'=>'c', 'M'=>6, 'N'=>3);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("KalmanGain.ah",
+                                    $propErr_pol, $resErrTmpLH, $K);
+
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- KH
+# KH = K * H
+
+$K   = new GenMul::Matrix('name'=>'a', 'M'=>6, 'N'=>3);
+$K->set_pattern(<<"FNORD");
+x x 0
+x x 0
+x x 0
+x x 0
+x x 0
+x x 0
+FNORD
+
+$H   = new GenMul::Matrix('name'=>'b', 'M'=>3, 'N'=>6);
+$H->set_pattern(<<"FNORD");
+x x 0 0 0 0
+0 0 1 0 0 0
+x x 0 0 0 0
+FNORD
+
+$KH   = new GenMul::Matrix('name'=>'c', 'M'=>6, 'N'=>6);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("KH.ah",
+                                    $K, $H, $KH);
+
+#------------------------------------------------------------------------------
+###updateParametersMPlex -- KH * C
+# temp = KH * propErr_pol
+
+$KH   = new GenMul::Matrix('name'=>'a', 'M'=>6, 'N'=>6);
+$KH->set_pattern(<<"FNORD");
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+FNORD
+
+$propErr_pol = new GenMul::MatrixSym('name'=>'b', 'M'=>6, 'N'=>6);
+
+$temp   = new GenMul::MatrixSym('name'=>'c', 'M'=>6, 'N'=>6);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("KHC.ah",
+                                    $KH, $propErr_pol, $temp);
+
+#------------------------------------------------------------------------------
+
+### computeChi2MPlex -- similarity to rotate errors, two ops.
+# resErr_loc = rotT * resErr_glo * rotTT
+
+$rotT = new GenMul::Matrix('name'=>'a', 'M'=>3, 'N'=>3);
+$rotT->set_pattern(<<"FNORD");
+x x 0
+0 0 1
+x x 0
+FNORD
+
+$resErr_glo = new GenMul::MatrixSym('name'=>'b', 'M'=>3, 'N'=>3);
+
+$temp   = new GenMul::Matrix('name'=>'c', 'M'=>3, 'N'=>3);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("ProjectResErr.ah",
+                                    $rotT, $resErr_glo, $temp);
+
+$roTT = new GenMul::MatrixTranspose($rotT);
+$resErr_loc = new GenMul::MatrixSym('name'=>'c', 'M'=>3, 'N'=>3);
+$temp  ->{name} = 'b';
+
+$m->dump_multiply_std_and_intrinsic("ProjectResErrTransp.ah",
+                                    $temp, $roTT, $resErr_loc);
+
+#------------------------------------------------------------------------------
 
 ### Propagate Helix To R -- final similarity, two ops.
 
 # outErr = errProp * outErr * errPropT
 #   outErr is symmetric
 
+my $DIM = 6;
 
 $errProp = new GenMul::Matrix('name'=>'a', 'M'=>$DIM, 'N'=>$DIM);
 $errProp->set_pattern(<<"FNORD");

--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -10,6 +10,7 @@ void BunchOfHits::Reset()
   }
 
   m_fill_index = 0;
+  m_fill_index_old = 0;
 }
 
 void BunchOfHits::SortByPhiBuildPhiBins()
@@ -51,7 +52,7 @@ void BunchOfHits::SortByPhiBuildPhiBins()
     //std::cout << "bin=" << b << " set to " << m_phi_bin_infos[b].first << "," << m_phi_bin_infos[b].second << std::endl;
   }
 
-  int m_fill_index_old = m_fill_index;
+  m_fill_index_old = m_fill_index;
   // Copy first g_MaxHitsConsidered to the end to simplify +/- pi break.
   for (int i = 0; i < Config::maxHitsConsidered && i < m_fill_index_old; ++i)
   {

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -52,13 +52,15 @@ public:
 
   int     m_real_size;
   int     m_fill_index;
+  int     m_fill_index_old;
 
 public:
   BunchOfHits() :
     //m_hits          (Config::maxHitsPerBunch),
     m_phi_bin_infos (Config::nPhiPart),
     m_real_size     (Config::maxHitsPerBunch),
-    m_fill_index    (0)
+    m_fill_index    (0),
+    m_fill_index_old(0)
   {
     m_hits = (Hit*) _mm_malloc(sizeof(Hit)*Config::maxHitsPerBunch, 64);
     Reset();

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -684,17 +684,16 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   MPlexLV outPar_pol;  // output parameters in "polar" coordinates
   MultResidualsAdd(K, propPar_pol, res_loc, outPar_pol);//fixme check vs old impl.
 
-  MPlexLS outErr_pol;  // output error in "polar" coordinates
   KHMult(K, rotT00, rotT01, tempLL);
-  KHC(tempLL, propErr_pol, outErr_pol);
-  outErr_pol.Subtract(propErr_pol, outErr_pol);
+  KHC(tempLL, propErr_pol, outErr);
+  outErr.Subtract(propErr_pol, outErr);// outErr is in "polar" coordinates now
 
   // Go back to cartesian coordinates
 
   // jac_pol is now the jacobian from "polar" to cartesian
   ConvertToCartesian(outPar_pol, outPar, jac_pol);
-  CartesianErr      (jac_pol, outErr_pol, tempLL);
-  CartesianErrTransp(jac_pol, tempLL, outErr);
+  CartesianErr      (jac_pol, outErr, tempLL);
+  CartesianErrTransp(jac_pol, tempLL, outErr);// outErr is in cartesian coordinates now
 
 #ifdef DEBUG
   if (dump) {
@@ -729,10 +728,6 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
     printf("outPar_pol:\n");
     for (int i = 0; i < 6; ++i) {
       printf("%8f  ", outPar_pol.At(0,i,0));
-    } printf("\n");
-    printf("outErr_pol:\n");
-    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-        printf("%8f ", outErr_pol.At(0,i,j)); printf("\n");
     } printf("\n");
     printf("outPar:\n");
     for (int i = 0; i < 6; ++i) {

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -504,21 +504,21 @@ void ConvertToCartesian(const MPlexLV& A, MPlexLV& B, MPlexLL& C)
     c[18*N+n] = 0.;
     c[19*N+n] = 0.;
     c[20*N+n] = 0.;
-    c[21*N+n] = -cosP/pow(a[ 3*N+n],2);
+    c[21*N+n] = -cosP/(a[ 3*N+n]*a[ 3*N+n]);
     c[22*N+n] = -sinP/a[ 3*N+n];
     c[23*N+n] = 0.;
     c[24*N+n] = 0.;
     c[25*N+n] = 0.;
     c[26*N+n] = 0.;
-    c[27*N+n] = -sinP/pow(a[ 3*N+n],2);
+    c[27*N+n] = -sinP/(a[ 3*N+n]*a[ 3*N+n]);
     c[28*N+n] =  cosP/a[ 3*N+n];
     c[29*N+n] = 0.;
     c[30*N+n] = 0.;
     c[31*N+n] = 0.;
     c[32*N+n] = 0.;
-    c[33*N+n] = -cosT/(sinT*pow(a[ 3*N+n],2));
+    c[33*N+n] = -cosT/(sinT*a[ 3*N+n]*a[ 3*N+n]);
     c[34*N+n] = 0.;
-    c[35*N+n] = -1./(pow(sinT,2)*a[ 3*N+n]);
+    c[35*N+n] = -1./(sinT*sinT*a[ 3*N+n]);
   }
 }
 

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -691,10 +691,10 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
   // Go back to cartesian coordinates
 
-  MPlexLL jac_back_pol; // jacobian from "polar" to cartesian
-  ConvertToCartesian(outPar_pol, outPar, jac_back_pol);
-  CartesianErr      (jac_back_pol, outErr_pol, tempLL);
-  CartesianErrTransp(jac_back_pol, tempLL, outErr);
+  // jac_pol is now the jacobian from "polar" to cartesian
+  ConvertToCartesian(outPar_pol, outPar, jac_pol);
+  CartesianErr      (jac_pol, outErr_pol, tempLL);
+  CartesianErrTransp(jac_pol, tempLL, outErr);
 
 #ifdef DEBUG
   if (dump) {
@@ -733,10 +733,6 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
     printf("outErr_pol:\n");
     for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
         printf("%8f ", outErr_pol.At(0,i,j)); printf("\n");
-    } printf("\n");
-    printf("jac_back_pol:\n");
-    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-        printf("%8f ", jac_back_pol.At(0,i,j)); printf("\n");
     } printf("\n");
     printf("outPar:\n");
     for (int i = 0; i < 6; ++i) {

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -68,7 +68,7 @@ void Chi2Similarity(const MPlexHV& A,//msPar
 #pragma simd
    for (idx_t n = 0; n < N; ++n)
    {
-      // manually subrtact into local vars -- 3 of them
+      // manually subtract into local vars -- 3 of them
       float x0 = a[0 * N + n] - b[0 * N + n];
       float x1 = a[1 * N + n] - b[1 * N + n];
       float x2 = a[2 * N + n] - b[2 * N + n];
@@ -83,6 +83,32 @@ void Chi2Similarity(const MPlexHV& A,//msPar
       // generate loop (can also write it manually this time, it's not much)
       d[0 * N + n] =    c[0 * N + n]*x0*x0 + c[2 * N + n]*x1*x1 + c[5 * N + n]*x2*x2 +
                     2*( c[1 * N + n]*x1*x0 + c[3 * N + n]*x2*x0 + c[4 * N + n]*x1*x2);
+   }
+}
+
+inline
+void Chi2Similarity(const MPlexHV& A,//resPar
+		    const MPlex2S& C,//resErr
+                          MPlexQF& D)//outChi2
+{
+
+   // outChi2 = (resPar) * resErr * (resPar)
+   //   D     =    A      *    C   *      A
+
+   // XXX Regenerate with a script.
+
+   typedef float T;
+   const idx_t N = NN;
+
+   const T *a = A.fArray; ASSUME_ALIGNED(a, 64);
+   const T *c = C.fArray; ASSUME_ALIGNED(c, 64);
+         T *d = D.fArray; ASSUME_ALIGNED(d, 64);
+
+#pragma simd
+   for (idx_t n = 0; n < N; ++n)
+   {
+      // generate loop (can also write it manually this time, it's not much)
+      d[0 * N + n] =    c[0 * N + n]*a[0 * N + n]*a[0 * N + n] + c[2 * N + n]*a[1 * N + n]*a[1 * N + n] + 2*( c[1 * N + n]*a[1 * N + n]*a[0 * N + n]);
    }
 }
 
@@ -171,6 +197,46 @@ void kalmanGain_x_propErr(const MPlexLH& A, const MPlexLS& B, MPlexLS& C)
 #include "upParam_kalmanGain_x_propErr.ah"
 }
 
+template<typename T1, typename T2, typename T3>
+void MultFull(const T1& A, int nia, int nja, const T2& B, int nib, int njb, T3& C, int nic, int njc)
+{
+
+  assert(nja==nib);
+  assert(nia==nic);
+  assert(njb==njc);
+
+#pragma simd
+  for (int n = 0; n < NN; ++n)
+    {
+      for (int i = 0; i < nia; ++i) {
+	for (int j = 0; j < njb; ++j) {
+	  C(n,i,j) = 0.;
+	  for (int k = 0; k < nja; ++k) C(n,i,j) += A.ConstAt(n,i,k)*B.ConstAt(n,k,j);
+	}
+      }
+    }
+}
+
+template<typename T1, typename T2, typename T3>
+void MultTranspFull(const T1& A, int nia, int nja, const T2& B, int nib, int njb, T3& C, int nic, int njc)
+{
+
+  assert(nja==njb);
+  assert(nia==nic);
+  assert(nib==njc);
+
+#pragma simd
+  for (int n = 0; n < NN; ++n)
+    {
+      for (int i = 0; i < nia; ++i) {
+	for (int j = 0; j < nib; ++j) {
+	  C(n,i,j) = 0.;
+	  for (int k = 0; k < nja; ++k) C(n,i,j) += A.ConstAt(n,i,k)*B.ConstAt(n,j,k);
+	}
+      }
+    }
+}
+
 }
 
 
@@ -230,47 +296,234 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   }
 #endif
 
-  MPlexHS resErr;
-  AddIntoUpperLeft3x3(propErr, msErr, resErr);
-  // Do not really need to zero the rest ... it is not used.
+  MPlexHH rot;//we may not need this one
+  MPlexHH rotT;
+  MPlexHV res_glo;
+  MPlexHS resErr_glo;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    float r = hipo(msPar.ConstAt(n, 0, 0), msPar.ConstAt(n, 1, 0));
+    rot.At(n, 0, 0) = -(msPar.ConstAt(n, 1, 0)+propPar.ConstAt(n, 1, 0))/(2*r);
+    rot.At(n, 0, 1) = 0;
+    rot.At(n, 0, 2) =  (msPar.ConstAt(n, 0, 0)+propPar.ConstAt(n, 0, 0))/(2*r);
+    rot.At(n, 1, 0) = rot.ConstAt(n, 0, 2);
+    rot.At(n, 1, 1) = 0;
+    rot.At(n, 1, 2) = -rot.ConstAt(n, 0, 0);
+    rot.At(n, 2, 0) = 0;
+    rot.At(n, 2, 1) = 1;
+    rot.At(n, 2, 2) = 0;
+    //
+    rotT.At(n, 0, 0) = rot.ConstAt(n, 0, 0);
+    rotT.At(n, 0, 1) = rot.ConstAt(n, 1, 0);
+    rotT.At(n, 0, 2) = rot.ConstAt(n, 2, 0);
+    rotT.At(n, 1, 0) = rot.ConstAt(n, 0, 1);
+    rotT.At(n, 1, 1) = rot.ConstAt(n, 1, 1);
+    rotT.At(n, 1, 2) = rot.ConstAt(n, 2, 1);
+    rotT.At(n, 2, 0) = rot.ConstAt(n, 0, 2);
+    rotT.At(n, 2, 1) = rot.ConstAt(n, 1, 2);
+    rotT.At(n, 2, 2) = rot.ConstAt(n, 2, 2);
+    //
+    for (int i = 0; i < 3; ++i) {
+      res_glo.At(n, i, 0) = msPar.ConstAt(n, i, 0) - propPar.ConstAt(n, i, 0);
+      for (int j = 0; j < 3; ++j) {
+	resErr_glo.At(n, i, j) = msErr.ConstAt(n,i,j) + propErr.ConstAt(n,i,j);
+      }
+    }
+  }
+
+  MPlexHV res_loc;
+  MultiplyGeneral(rotT,res_glo,res_loc);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("res_loc:\n");
+    for (int i = 0; i < 3; ++i) {
+        printf("%8f ", res_loc.At(0,i,0));
+    } printf("\n");
+  }
+#endif
+
+  MPlexHS resErr_loc;
+  MPlexHH temp;
+  MultFull      (rotT,3,3, resErr_glo,3,3, temp,3,3);
+  MultTranspFull(rotT,3,3, temp,3,3, resErr_loc,3,3);
+
+  MPlex2S resErr;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 2; ++i) {
+      for (int j = i; j < 2; ++j) {
+	resErr.At(n, i, j) = resErr_loc.ConstAt(n,i,j);
+      }
+    }
+  }
 
 #ifdef DEBUG
   if (dump) {
     printf("resErr:\n");
-    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr.At(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
   Matriplex::InvertCramerSym(resErr);
-  // Matriplex::InvertCholeskySym(resErr);
-  // resErr is now resErrInv
-  // XXX Both could be done in one operation.
 
 #ifdef DEBUG
   if (dump) {
     printf("resErrInv:\n");
-    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr.At(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
-  MPlexLH kalmanGain;
-  MultKalmanGain(propErr, resErr, kalmanGain);
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 3; ++i) {
+      for (int j = i; j < 3; ++j) {
+	if (i==2||j==2) resErr_loc.At(n, i, j) = 0.;
+	else resErr_loc.At(n, i, j) = resErr.ConstAt(n,i,j);
+      }
+    }
+  }
+
 
 #ifdef DEBUG
   if (dump) {
-    printf("kalmanGain:\n");
-    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 3; ++j)
-        printf("%8f ", kalmanGain.At(0,i,j)); printf("\n");
+    printf("resErr_loc:\n");
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+        printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
-  // outPar = psPar + kalmanGain*(msPar-psPar)[0-2] (last three are 0!)
-  MultResidualsAdd(kalmanGain, propPar, msPar, outPar);
+  MPlexHH resErrTmp;
+  MultFull(rot,3,3, resErr_loc,3,3, resErrTmp,3,3);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("resErrTmp:\n");
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+        printf("%8f ", resErrTmp.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLH resErrTmpLH;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 3; ++j) {
+	if (i>2) resErrTmpLH.At(n, i, j) = 0.;
+	else resErrTmpLH.At(n, i, j) = resErrTmp.ConstAt(n,i,j);
+      }
+    }
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("resErrTmpLH:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 3; ++j)
+        printf("%8f ", resErrTmpLH.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLV propPar_pol;
+  MPlexLL jac_pol;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    //propPar_pol
+    for (int i = 0; i < 3; ++i) {
+      propPar_pol.At(n, i, 0) = propPar.At(n, i, 0);
+    }
+    float pt = getHypot(propPar.At(n, 3, 0), propPar.At(n, 4, 0));
+    propPar_pol.At(n, 3, 0) = 1./pt;
+    propPar_pol.At(n, 4, 0) = getPhi(propPar.At(n, 3, 0), propPar.At(n, 4, 0));
+    propPar_pol.At(n, 5, 0) = getTheta(pt, propPar.At(n, 5, 0));
+    //jac_pol:first set to identity, then modify the relevant terms
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+	if (i==j) jac_pol.At(n, i, j) = 1.;
+	else jac_pol.At(n, i, j) = 0.;
+      }
+    }
+    jac_pol.At(n, 3, 3) = -propPar.At(n, 3, 0)/(pt*pt*pt);
+    jac_pol.At(n, 3, 4) = -propPar.At(n, 4, 0)/(pt*pt*pt);
+    jac_pol.At(n, 4, 3) = -propPar.At(n, 4, 0)/(pt*pt);
+    jac_pol.At(n, 4, 4) =  propPar.At(n, 3, 0)/(pt*pt);
+    float p2 = pt*pt + propPar.At(n, 5, 0)*propPar.At(n, 5, 0);
+    jac_pol.At(n, 5, 3) =  propPar.At(n, 3, 0)*propPar.At(n, 5, 0)/(pt*p2);
+    jac_pol.At(n, 5, 4) =  propPar.At(n, 4, 0)*propPar.At(n, 5, 0)/(pt*p2);
+    jac_pol.At(n, 5, 5) = -pt/p2;
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("jac_pol:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", jac_pol.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLS propErr_pol;
+  MPlexLL propErr_tmp;
+  MultFull(jac_pol,6,6,propErr,6,6,propErr_tmp,6,6);
+  MultTranspFull(propErr_tmp,6,6,jac_pol,6,6,propErr_pol,6,6);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("propErr_pol:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", propErr_pol.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLH K;
+  MultFull(propErr_pol,6,6,resErrTmpLH,6,3,K,6,3);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("K:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 3; ++j)
+        printf("%8f ", K.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLV dPar;
+  MultFull(K,6,3,res_loc,3,1,dPar,6,1);
+
+  MPlexLV outPar_pol;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 6; ++i) {
+      outPar_pol.At(n, i, 0) = propPar_pol.At(n, i, 0) + dPar.At(n, i, 0);
+    }
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("outPar_pol:\n");
+    for (int i = 0; i < 6; ++i) {
+      printf("%8f  ", outPar_pol.At(0,i,0));
+    } printf("\n");
+    printf("\n");
+  }
+#endif
+
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 3; ++i) {
+      outPar.At(n, i, 0) = outPar_pol.At(n, i, 0);
+    }
+    outPar.At(n, 3, 0) = cos(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
+    outPar.At(n, 4, 0) = sin(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
+    outPar.At(n, 5, 0) = cos(outPar_pol.At(n, 5, 0))/(sin(outPar_pol.At(n, 5, 0))*outPar_pol.At(n, 3, 0));
+  }
 
 #ifdef DEBUG
   if (dump) {
@@ -278,17 +531,159 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
     for (int i = 0; i < 6; ++i) {
       printf("%8f  ", outPar.At(0,i,0));
     } printf("\n");
+    printf("\n");
   }
 #endif
 
-  // outErr = propErr - ROOT::Math::SimilarityT(propErr,resErrInv);
-  //        = propErr - kalmanGain*propErr
-  //
-  // XXX Ideally would also subtract at the same time in auto generated code.
+  MPlexLS I66;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+	if (i==j) I66.At(n, i, j) = 1.;
+	else I66.At(n, i, j) = 0.;
+      }
+    }
+  }
 
-  MPlexLS outErrTemp;
-  kalmanGain_x_propErr(kalmanGain, propErr, outErrTemp);
-  outErr.Subtract(propErr, outErrTemp);
+  MPlexHL H;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 6; ++j) {
+	if (j>2) H.At(n, i, j) = 0.;
+	else H.At(n, i, j) = rotT.At(n, i, j);
+      }
+    }
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("H:\n");
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", H.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexHS locErrMeas;
+  MultFull      (rotT,3,3, msErr,3,3, temp,3,3);
+  MultTranspFull(rotT,3,3, temp,3,3, locErrMeas,3,3);
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    locErrMeas.At(n, 2, 0) = 0;
+    locErrMeas.At(n, 2, 1) = 0;
+    locErrMeas.At(n, 2, 2) = 0;
+    //locErrMeas.At(n, 1, 2) = 0;
+    //locErrMeas.At(n, 0, 2) = 0;
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("locErrMeas:\n");
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+        printf("%8f ", locErrMeas.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLS T1;
+  MPlexLL tmp1;
+  MPlexLL tmp11;
+  MultFull(K,6,3,H,3,6,tmp1,6,6);
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+	tmp1.At(n, i, j) = I66.At(n, i, j) - tmp1.At(n, i, j);
+      }
+    }
+  }
+  MultFull(tmp1,6,6,propErr_pol,6,6,tmp11,6,6);
+  MultTranspFull(tmp11,6,6,tmp1,6,6,T1,6,6);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("T1:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", T1.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLS T2;
+  MPlexHL tmp2;
+  MultTranspFull(locErrMeas,3,3,K,6,3,tmp2,3,6);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("tmp2:\n");
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", tmp2.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MultFull(K,6,3,tmp2,3,6,T2,6,6);
+
+#ifdef DEBUG
+  if (dump) {
+    printf("T2:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", T2.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLS outErr_pol;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 6; ++i) {
+      for (int j = i; j < 6; ++j) {
+	outErr_pol.At(n, i, j) = T1.At(n, i, j) + T2.At(n, i, j);
+      }
+    }
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("outErr_pol:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", outErr_pol.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLL jac_back_pol;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    //jac_back_pol:first set to identity, then modify the relevant terms
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+	if (i==j) jac_back_pol.At(n, i, j) = 1.;
+	else jac_back_pol.At(n, i, j) = 0.;
+      }
+    }
+    jac_back_pol.At(n, 3, 3) = -cos(outPar_pol.At(n, 4, 0))/pow(outPar_pol.At(n, 3, 0),2);
+    jac_back_pol.At(n, 3, 4) = -sin(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
+    jac_back_pol.At(n, 4, 3) = -sin(outPar_pol.At(n, 4, 0))/pow(outPar_pol.At(n, 3, 0),2);
+    jac_back_pol.At(n, 4, 4) =  cos(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
+    jac_back_pol.At(n, 5, 3) = -cos(outPar_pol.At(n, 5, 0))/(sin(outPar_pol.At(n, 5, 0))*pow(outPar_pol.At(n, 3, 0),2));
+    jac_back_pol.At(n, 5, 5) = -1./(pow(sin(outPar_pol.At(n, 5, 0)),2)*outPar_pol.At(n, 3, 0));
+  }
+
+#ifdef DEBUG
+  if (dump) {
+    printf("jac_back_pol:\n");
+    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+        printf("%8f ", jac_back_pol.At(0,i,j)); printf("\n");
+    } printf("\n");
+  }
+#endif
+
+  MPlexLL outErr_tmp;
+  MultFull(jac_back_pol,6,6,outErr_pol,6,6,outErr_tmp,6,6);
+  MultTranspFull(outErr_tmp,6,6,jac_back_pol,6,6,outErr,6,6);
 
 #ifdef DEBUG
   if (dump) {
@@ -337,47 +732,92 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
     for (int i = 0; i < 6; ++i) { 
       printf("%8f ", propPar.ConstAt(0,0,i)); printf("\n");
     } printf("\n");
-    printf("msPar:\n");
-    for (int i = 0; i < 3; ++i) { 
-      printf("%8f ", msPar.ConstAt(0,0,i)); printf("\n");
-    } printf("\n");
     printf("propErr:\n");
     for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
         printf("%8f ", propErr.At(0,i,j)); printf("\n");
     } printf("\n");
+    printf("msPar:\n");
+    for (int i = 0; i < 3; ++i) {
+      printf("%8f ", msPar.ConstAt(0,0,i)); printf("\n");
+    } printf("\n");
     printf("msErr:\n");
-    for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
+    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
         printf("%8f ", msErr.ConstAt(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
-  MPlexHS resErr;
-  AddIntoUpperLeft3x3(propErr, msErr, resErr);
-  // Do not really need to zero the rest ... it is not used.
+  MPlexHH rot;//we may not need this one
+  MPlexHH rotT;
+  MPlexHV res_glo;
+  MPlexHS resErr_glo;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    float r = hipo(msPar.ConstAt(n, 0, 0), msPar.ConstAt(n, 1, 0));
+    rot.At(n, 0, 0) = -(msPar.ConstAt(n, 1, 0)+propPar.ConstAt(n, 1, 0))/(2*r);
+    rot.At(n, 0, 1) = 0;
+    rot.At(n, 0, 2) =  (msPar.ConstAt(n, 0, 0)+propPar.ConstAt(n, 0, 0))/(2*r);
+    rot.At(n, 1, 0) = rot.ConstAt(n, 0, 2);
+    rot.At(n, 1, 1) = 0;
+    rot.At(n, 1, 2) = -rot.ConstAt(n, 0, 0);
+    rot.At(n, 2, 0) = 0;
+    rot.At(n, 2, 1) = 1;
+    rot.At(n, 2, 2) = 0;
+    //
+    rotT.At(n, 0, 0) = rot.ConstAt(n, 0, 0);
+    rotT.At(n, 0, 1) = rot.ConstAt(n, 1, 0);
+    rotT.At(n, 0, 2) = rot.ConstAt(n, 2, 0);
+    rotT.At(n, 1, 0) = rot.ConstAt(n, 0, 1);
+    rotT.At(n, 1, 1) = rot.ConstAt(n, 1, 1);
+    rotT.At(n, 1, 2) = rot.ConstAt(n, 2, 1);
+    rotT.At(n, 2, 0) = rot.ConstAt(n, 0, 2);
+    rotT.At(n, 2, 1) = rot.ConstAt(n, 1, 2);
+    rotT.At(n, 2, 2) = rot.ConstAt(n, 2, 2);
+    //
+    for (int i = 0; i < 3; ++i) {
+      res_glo.At(n, i, 0) = msPar.ConstAt(n, i, 0) - propPar.ConstAt(n, i, 0);
+      for (int j = 0; j < 3; ++j) {
+	resErr_glo.At(n, i, j) = msErr.ConstAt(n,i,j) + propErr.ConstAt(n,i,j);
+      }
+    }
+  }
+
+  MPlexHV res_loc;
+  MultiplyGeneral(rotT,res_glo,res_loc);
+  MPlexHS resErr_loc;
+  MPlexHH temp;
+  MultFull      (rotT,3,3, resErr_glo,3,3, temp,3,3);
+  MultTranspFull(rotT,3,3, temp,3,3, resErr_loc,3,3);
+
+  MPlex2S resErr;
+#pragma simd
+  for (int n = 0; n < NN; ++n) {
+    for (int i = 0; i < 2; ++i) {
+      for (int j = i; j < 2; ++j) {
+	resErr.At(n, i, j) = resErr_loc.ConstAt(n,i,j);
+      }
+    }
+  }
 
 #ifdef DEBUG
   if (dump) {
     printf("resErr:\n");
-    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr.At(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
   Matriplex::InvertCramerSym(resErr);
-  // Matriplex::InvertCholeskySym(resErr);
-  // resErr is now resErrInv
-  // XXX Both could be done in one operation.
 
 #ifdef DEBUG
   if (dump) {
     printf("resErrInv:\n");
-    for (int i = 0; i < 3; ++i) { for (int j = 0; j < 3; ++j)
+    for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr.At(0,i,j)); printf("\n");
     } printf("\n");
   }
 #endif
 
-  Chi2Similarity(msPar, propPar, resErr, outChi2);
+  Chi2Similarity(res_loc, resErr, outChi2);
 }

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -394,6 +394,134 @@ void KHC(const MPlexLL& A, const MPlexLS& B, MPlexLS& C)
 #include "KHC.ah"
 }
 
+inline
+void ConvertToPolar(const MPlexLV& A, MPlexLV& B, MPlexLL& C)
+{
+ 
+  typedef float T;
+  const idx_t N = NN;
+  
+  const T *a = A.fArray; ASSUME_ALIGNED(a, 64);
+        T *b = B.fArray; ASSUME_ALIGNED(b, 64);
+        T *c = C.fArray; ASSUME_ALIGNED(c, 64);
+
+#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    float pt = getHypot(a[ 3*N+n], a[ 4*N+n]);
+    float p2 = pt*pt + a[ 5*N+n]*a[ 5*N+n];
+    //
+    b[ 0*N+n] = a[ 0*N+n];
+    b[ 1*N+n] = a[ 1*N+n];
+    b[ 2*N+n] = a[ 2*N+n];
+    b[ 3*N+n] = 1./pt;
+    b[ 4*N+n] = getPhi(a[ 3*N+n], a[ 4*N+n]); //fixme: use trig approx
+    b[ 5*N+n] = getTheta(pt, a[ 5*N+n]);
+    //
+    c[ 0*N+n] = 1.;
+    c[ 1*N+n] = 0.;
+    c[ 2*N+n] = 0.;
+    c[ 3*N+n] = 0.;
+    c[ 4*N+n] = 0.;
+    c[ 5*N+n] = 0.;
+    c[ 6*N+n] = 0.;
+    c[ 7*N+n] = 1.;
+    c[ 8*N+n] = 0.;
+    c[ 9*N+n] = 0.;
+    c[10*N+n] = 0.;
+    c[11*N+n] = 0.;
+    c[12*N+n] = 0.;
+    c[13*N+n] = 0.;
+    c[14*N+n] = 1.;
+    c[15*N+n] = 0.;
+    c[16*N+n] = 0.;
+    c[17*N+n] = 0.;
+    c[18*N+n] = 0.;
+    c[19*N+n] = 0.;
+    c[20*N+n] = 0.;
+    c[21*N+n] = -a[ 3*N+n]/(pt*pt*pt);
+    c[22*N+n] = -a[ 4*N+n]/(pt*pt*pt);
+    c[23*N+n] = 0.;
+    c[24*N+n] = 0.;
+    c[25*N+n] = 0.;
+    c[26*N+n] = 0.;
+    c[27*N+n] = -a[ 4*N+n]/(pt*pt);
+    c[28*N+n] =  a[ 3*N+n]/(pt*pt);
+    c[29*N+n] = 0.;
+    c[30*N+n] = 0.;
+    c[31*N+n] = 0.;
+    c[32*N+n] = 0.;
+    c[33*N+n] =  a[ 3*N+n]*a[ 5*N+n]/(pt*p2);
+    c[34*N+n] =  a[ 4*N+n]*a[ 5*N+n]/(pt*p2);
+    c[35*N+n] = -pt/p2;
+  }
+}
+
+inline
+void ConvertToCartesian(const MPlexLV& A, MPlexLV& B, MPlexLL& C)
+{
+ 
+  typedef float T;
+  const idx_t N = NN;
+  
+  const T *a = A.fArray; ASSUME_ALIGNED(a, 64);
+        T *b = B.fArray; ASSUME_ALIGNED(b, 64);
+        T *c = C.fArray; ASSUME_ALIGNED(c, 64);
+
+#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    float cosP = cos(a[ 4*N+n]); //fixme: use trig approx
+    float sinP = sin(a[ 4*N+n]);
+    float cosT = cos(a[ 5*N+n]);
+    float sinT = sin(a[ 5*N+n]);
+    //
+    b[ 0*N+n] = a[ 0*N+n];
+    b[ 1*N+n] = a[ 1*N+n];
+    b[ 2*N+n] = a[ 2*N+n];
+    b[ 3*N+n] = cosP/a[ 3*N+n];
+    b[ 4*N+n] = sinP/a[ 3*N+n];
+    b[ 5*N+n] = cosT/(sinT*a[ 3*N+n]);
+    //
+    c[ 0*N+n] = 1.;
+    c[ 1*N+n] = 0.;
+    c[ 2*N+n] = 0.;
+    c[ 3*N+n] = 0.;
+    c[ 4*N+n] = 0.;
+    c[ 5*N+n] = 0.;
+    c[ 6*N+n] = 0.;
+    c[ 7*N+n] = 1.;
+    c[ 8*N+n] = 0.;
+    c[ 9*N+n] = 0.;
+    c[10*N+n] = 0.;
+    c[11*N+n] = 0.;
+    c[12*N+n] = 0.;
+    c[13*N+n] = 0.;
+    c[14*N+n] = 1.;
+    c[15*N+n] = 0.;
+    c[16*N+n] = 0.;
+    c[17*N+n] = 0.;
+    c[18*N+n] = 0.;
+    c[19*N+n] = 0.;
+    c[20*N+n] = 0.;
+    c[21*N+n] = -cosP/pow(a[ 3*N+n],2);
+    c[22*N+n] = -sinP/a[ 3*N+n];
+    c[23*N+n] = 0.;
+    c[24*N+n] = 0.;
+    c[25*N+n] = 0.;
+    c[26*N+n] = 0.;
+    c[27*N+n] = -sinP/pow(a[ 3*N+n],2);
+    c[28*N+n] =  cosP/a[ 3*N+n];
+    c[29*N+n] = 0.;
+    c[30*N+n] = 0.;
+    c[31*N+n] = 0.;
+    c[32*N+n] = 0.;
+    c[33*N+n] = -cosT/(sinT*pow(a[ 3*N+n],2));
+    c[34*N+n] = 0.;
+    c[35*N+n] = -1./(pow(sinT,2)*a[ 3*N+n]);
+  }
+}
+
 
 // //Warning: MultFull is not vectorized, use only for testing!
 // template<typename T1, typename T2, typename T3>
@@ -542,32 +670,7 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
   MPlexLV propPar_pol;// propagated parameters in "polar" coordinates
   MPlexLL jac_pol;    // jacobian from cartesian to "polar"
-  for (int n = 0; n < NN; ++n) {
-    //propPar_pol
-    for (int i = 0; i < 3; ++i) {
-      propPar_pol.At(n, i, 0) = propPar.At(n, i, 0);
-    }
-    float pt = getHypot(propPar.At(n, 3, 0), propPar.At(n, 4, 0));
-    propPar_pol.At(n, 3, 0) = 1./pt;
-    //fixme: use trig approx
-    propPar_pol.At(n, 4, 0) = getPhi(propPar.At(n, 3, 0), propPar.At(n, 4, 0));
-    propPar_pol.At(n, 5, 0) = getTheta(pt, propPar.At(n, 5, 0));
-    //jac_pol:first set to identity, then modify the relevant terms
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 6; ++j) {
-	if (i==j) jac_pol.At(n, i, j) = 1.;
-	else jac_pol.At(n, i, j) = 0.;
-      }
-    }
-    jac_pol.At(n, 3, 3) = -propPar.At(n, 3, 0)/(pt*pt*pt);
-    jac_pol.At(n, 3, 4) = -propPar.At(n, 4, 0)/(pt*pt*pt);
-    jac_pol.At(n, 4, 3) = -propPar.At(n, 4, 0)/(pt*pt);
-    jac_pol.At(n, 4, 4) =  propPar.At(n, 3, 0)/(pt*pt);
-    float p2 = pt*pt + propPar.At(n, 5, 0)*propPar.At(n, 5, 0);
-    jac_pol.At(n, 5, 3) =  propPar.At(n, 3, 0)*propPar.At(n, 5, 0)/(pt*p2);
-    jac_pol.At(n, 5, 4) =  propPar.At(n, 4, 0)*propPar.At(n, 5, 0)/(pt*p2);
-    jac_pol.At(n, 5, 5) = -pt/p2;
-  }
+  ConvertToPolar(propPar,propPar_pol,jac_pol);
 
   MPlexLS propErr_pol; // propagated errors in "polar" coordinates
   PolarErr      (jac_pol, propErr, tempLL);
@@ -588,35 +691,8 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
   // Go back to cartesian coordinates
 
-  // output parameters
-  for (int n = 0; n < NN; ++n) {
-    for (int i = 0; i < 3; ++i) {
-      outPar.At(n, i, 0) = outPar_pol.At(n, i, 0);
-    }
-    //fixme: use trig approx
-    outPar.At(n, 3, 0) = cos(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
-    outPar.At(n, 4, 0) = sin(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
-    outPar.At(n, 5, 0) = cos(outPar_pol.At(n, 5, 0))/(sin(outPar_pol.At(n, 5, 0))*outPar_pol.At(n, 3, 0));
-  }
-
-  // output errors
   MPlexLL jac_back_pol; // jacobian from "polar" to cartesian
-  for (int n = 0; n < NN; ++n) {
-    //jac_back_pol:first set to identity, then modify the relevant terms
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 6; ++j) {
-	if (i==j) jac_back_pol.At(n, i, j) = 1.;
-	else jac_back_pol.At(n, i, j) = 0.;
-      }
-    }
-    //fixme: use trig approx
-    jac_back_pol.At(n, 3, 3) = -cos(outPar_pol.At(n, 4, 0))/pow(outPar_pol.At(n, 3, 0),2);
-    jac_back_pol.At(n, 3, 4) = -sin(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
-    jac_back_pol.At(n, 4, 3) = -sin(outPar_pol.At(n, 4, 0))/pow(outPar_pol.At(n, 3, 0),2);
-    jac_back_pol.At(n, 4, 4) =  cos(outPar_pol.At(n, 4, 0))/outPar_pol.At(n, 3, 0);
-    jac_back_pol.At(n, 5, 3) = -cos(outPar_pol.At(n, 5, 0))/(sin(outPar_pol.At(n, 5, 0))*pow(outPar_pol.At(n, 3, 0),2));
-    jac_back_pol.At(n, 5, 5) = -1./(pow(sin(outPar_pol.At(n, 5, 0)),2)*outPar_pol.At(n, 3, 0));
-  }
+  ConvertToCartesian(outPar_pol, outPar, jac_back_pol);
   CartesianErr      (jac_back_pol, outErr_pol, tempLL);
   CartesianErrTransp(jac_back_pol, tempLL, outErr);
 
@@ -654,10 +730,6 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
     for (int i = 0; i < 6; ++i) {
       printf("%8f  ", outPar_pol.At(0,i,0));
     } printf("\n");
-    printf("outPar:\n");
-    for (int i = 0; i < 6; ++i) {
-      printf("%8f  ", outPar.At(0,i,0));
-    } printf("\n");
     printf("outErr_pol:\n");
     for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
         printf("%8f ", outErr_pol.At(0,i,j)); printf("\n");
@@ -665,6 +737,10 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
     printf("jac_back_pol:\n");
     for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
         printf("%8f ", jac_back_pol.At(0,i,j)); printf("\n");
+    } printf("\n");
+    printf("outPar:\n");
+    for (int i = 0; i < 6; ++i) {
+      printf("%8f  ", outPar.At(0,i,0));
     } printf("\n");
     printf("outErr:\n");
     for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -68,38 +68,22 @@ void MkBuilder::begin_event(Event* ev, EventTmp* ev_tmp, const char* build_type)
   for (int itrack = 0; itrack < simtracks.size(); ++itrack)
   {
     Track track = simtracks[itrack];
-    std::cout << "MX - simtrack with nHits=" << track.nFoundHits() << " chi2=" << track.chi2()  << " pT=" << sqrt(track.momentum()[0]*track.momentum()[0]+track.momentum()[1]*track.momentum()[1]) <<" phi="<< track.momPhi() <<" eta=" << track.momEta() << std::endl;
-  }
-#endif
-
-#ifdef DEBUG
-  for (int itrack = 0; itrack < simtracks.size(); ++itrack)
-  {
-    Track track = simtracks[itrack];
+    if (track.label() != itrack)
+    {
+      printf("Bad label for simtrack %d -- %d\n", itrack, track.label());
+    }
     std::cout << "MX - simtrack with nHits=" << track.nFoundHits() << " chi2=" << track.chi2()  << " pT=" << sqrt(track.momentum()[0]*track.momentum()[0]+track.momentum()[1]*track.momentum()[1]) <<" phi="<< track.momPhi() <<" eta=" << track.momEta() << std::endl;
   }
 #endif
 
   m_event_of_hits.Reset();
 
-  for (int itrack = 0; itrack < simtracks.size(); ++itrack)
+  //fill vector of hits in each layer (assuming there is one hit per layer in hits vector)
+  for (int ilay = 0; ilay<m_event->layerHits_.size();++ilay) 
   {
-
-    if (simtracks[itrack].label() != itrack)
+    for (int ihit = 0; ihit<m_event->layerHits_[ilay].size();++ihit) 
     {
-      printf("Bad label for simtrack %d -- %d\n", itrack, simtracks[itrack].label());
-    }
-
-    //fill vector of hits in each layer (assuming there is one hit per layer in hits vector)
-    for (int ilay = 0; ilay < simtracks[itrack].nTotalHits(); ++ilay)
-    {
-      m_event_of_hits.InsertHit(simtracks[itrack].hitsVector(m_event->layerHits_)[ilay], ilay);
-#ifdef DEBUG
-      std::cout << "track #" << itrack << " lay=" << ilay+1
-                << " hit pos=" << simtracks[itrack].hitsVector(m_event->layerHits_)[ilay].position()
-                << " phi=" << simtracks[itrack].hitsVector(m_event->layerHits_)[ilay].phi()
-                << " phiPart=" << getPhiPartition(simtracks[itrack].hitsVector(m_event->layerHits_)[ilay].phi()) << std::endl;
-#endif
+      m_event_of_hits.InsertHit(m_event->layerHits_[ilay][ihit],ilay);
     }
   }
 
@@ -150,14 +134,6 @@ void MkBuilder::fit_seeds()
   }
 #endif
 
-#ifdef DEBUG
-  std::cout << "found total seeds=" << m_recseeds.size() << std::endl;
-  for (int iseed = 0; iseed < m_recseeds.size(); ++iseed)
-  {
-    Track& seed = m_recseeds[iseed];
-    std::cout << "MX - found seed with nHits=" << seed.nFoundHits() << " chi2=" << seed.chi2() << " posEta=" << seed.posEta() << " posPhi=" << seed.posPhi() << " posR=" << seed.posR() << " pT=" << seed.pT() << std::endl;
-  }
-#endif
 }
 
 void MkBuilder::end_event()
@@ -184,31 +160,29 @@ void MkBuilder::quality_process(Track &tkcand)
   float pt    = tkcand.pT();
   float ptmc  = m_event->simTracks_[mctrk].pT() ;
   float pr    = pt / ptmc;
+  int nfoundmc = m_event->simTracks_[mctrk].nFoundHits();
 
   ++m_cnt;
   if (pr > 0.9 && pr < 1.1) ++m_cnt1;
   if (pr > 0.8 && pr < 1.2) ++m_cnt2;
 
-  if (tkcand.nFoundHits() >= 8)
+  if (tkcand.nFoundHits() >= 0.8*nfoundmc)
   {
     ++m_cnt_8;
     if (pr > 0.9 && pr < 1.1) ++m_cnt1_8;
     if (pr > 0.8 && pr < 1.2) ++m_cnt2_8;
   }
 
-#ifdef DEBUG
-  std::cout << "MX - found track with nFoundHits=" << tkcand.nFoundHits() << " chi2=" << tkcand.chi2() << " pT=" << pt <<" pTmc="<< ptmc <<" lab="<< tkcand.label() <<std::endl;
+#if defined(DEBUG) || defined(PRINTOUTS_FOR_PLOTS)
+  std::cout << "MX - found track with nFoundHits=" << tkcand.nFoundHits() << " chi2=" << tkcand.chi2() << " pT=" << pt <<" pTmc="<< ptmc << " nfoundmc=" << nfoundmc <<" lab="<< tkcand.label() <<std::endl;
 #endif
 
-#ifdef PRINTOUTS_FOR_PLOTS
-  std::cout << "MX - found track with nFoundHits=" << tkcand.nFoundHits() << " chi2=" << tkcand.chi2() << " pT=" << pt <<" pTmc="<< ptmc << std::endl;
-#endif
 }
 
 void MkBuilder::quality_print()
 {
   std::cout << "found tracks=" << m_cnt   << "  in pT 10%=" << m_cnt1   << "  in pT 20%=" << m_cnt2   << "     no_mc_assoc="<< m_cnt_nomc <<std::endl;
-  std::cout << "  nH >= 8   =" << m_cnt_8 << "  in pT 10%=" << m_cnt1_8 << "  in pT 20%=" << m_cnt2_8 << std::endl;
+  std::cout << "  nH >= 80% =" << m_cnt_8 << "  in pT 10%=" << m_cnt1_8 << "  in pT 20%=" << m_cnt2_8 << std::endl;
 }
 
 

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -19,8 +19,6 @@ private:
 
   std::vector<MkFitter*> m_mkfp_arr;
 
-  std::vector<Track>     m_recseeds;
-
   int m_cnt=0, m_cnt1=0, m_cnt2=0, m_cnt_8=0, m_cnt1_8=0, m_cnt2_8=0, m_cnt_nomc=0;
 
 public:

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -423,7 +423,7 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
 #ifdef DEBUG
       std::cout << "update parameters" << std::endl;
       std::cout << "propagated track parameters x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl;
-      std::cout << "               hit position x=" << msPar[iP].ConstAt(itrack, 0, 0) << " y=" << msPar[iP].ConstAt(itrack, 1, 0) << std::endl;
+      std::cout << "               hit position x=" << msPar_oneHit.ConstAt(itrack, 0, 0) << " y=" << msPar_oneHit.ConstAt(itrack, 1, 0) << std::endl;
       std::cout << "   updated track parameters x=" << Par[iC].ConstAt(itrack, 0, 0) << " y=" << Par[iC].ConstAt(itrack, 1, 0) << std::endl;
 #endif
 
@@ -1035,7 +1035,7 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
 #ifdef DEBUG
       std::cout << "update parameters" << std::endl;
       std::cout << "propagated track parameters x=" << Par[iP].ConstAt(0, 0, 0) << " y=" << Par[iP].ConstAt(0, 1, 0) << std::endl;
-      std::cout << "               hit position x=" << msPar[iP].ConstAt(0, 0, 0) << " y=" << msPar[iP].ConstAt(0, 1, 0) << std::endl;
+      std::cout << "               hit position x=" << msPar[Nhits].ConstAt(0, 0, 0) << " y=" << msPar[Nhits].ConstAt(0, 1, 0) << std::endl;
       std::cout << "   updated track parameters x=" << Par[iC].ConstAt(0, 0, 0) << " y=" << Par[iC].ConstAt(0, 1, 0) << std::endl;
 #endif
 

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -719,9 +719,7 @@ void MkFitter::SelectHitRanges(BunchOfHits &bunch_of_hits, const int N_proc)
 #ifdef DEBUG
       xout << "XHitSize=" << XHitSize.At(itrack, 0, 0) << "  bunch_of_hits.m_fill_index=" <<  bunch_of_hits.m_fill_index << " Config::maxHitsConsidered=" << Config::maxHitsConsidered << std::endl;
 #endif
-      // XXX It would be nice to have BunchOfHits.m_n_real_hits.
-      //XHitSize.At(itrack, 0, 0) += bunch_of_hits.m_fill_index - Config::maxHitsConsidered;//this can be negative!
-      XHitSize.At(itrack, 0, 0) = std::min(int(bunch_of_hits.m_fill_index),int(Config::maxHitsConsidered));//fixme: not sure this is the desired behavior
+      XHitSize.At(itrack, 0, 0) += bunch_of_hits.m_fill_index_old;
     }
 
     // XXXX Hack to limit N_hits to maxHitsConsidered.
@@ -848,7 +846,6 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
     msErr[Nhits].SlurpIn(varr + off_error, idx);
     msPar[Nhits].SlurpIn(varr + off_param, idx);
 #endif
-
 #endif //NO_GATHER
 
     //now compute the chi2 of track state vs hit
@@ -867,6 +864,8 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
 #pragma simd
     for (int itrack = 0; itrack < NN; ++itrack)
     {
+      // make sure the hit was in the compatiblity window for the candidate
+      if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
       float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
 #ifdef DEBUG
       std::cout << "chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack] << std::endl;      
@@ -1037,6 +1036,8 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
     bool oneCandPassCut = false;
     for (int itrack = 0; itrack < N_proc;++itrack)
       {
+	// make sure the hit was in the compatiblity window for the candidate
+	if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
 	float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
 #ifdef DEBUG
 	std::cout << "chi2=" << chi2 << std::endl;
@@ -1062,6 +1063,8 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
       //fixme: please vectorize me... (not sure it's possible in this case)
       for (int itrack = 0; itrack < N_proc; ++itrack)
 	{
+	  // make sure the hit was in the compatiblity window for the candidate
+	  if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
 	  float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
 #ifdef DEBUG
 	  std::cout << "chi2=" << chi2 << std::endl;      

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -716,8 +716,12 @@ void MkFitter::SelectHitRanges(BunchOfHits &bunch_of_hits, const int N_proc)
     XHitSize.At(itrack, 0, 0) = binInfoPlus .first + binInfoPlus.second - binInfoMinus.first;
     if (XHitSize.At(itrack, 0, 0) < 0)
     {
+#ifdef DEBUG
+      xout << "XHitSize=" << XHitSize.At(itrack, 0, 0) << "  bunch_of_hits.m_fill_index=" <<  bunch_of_hits.m_fill_index << " Config::maxHitsConsidered=" << Config::maxHitsConsidered << std::endl;
+#endif
       // XXX It would be nice to have BunchOfHits.m_n_real_hits.
-      XHitSize.At(itrack, 0, 0) += bunch_of_hits.m_fill_index - Config::maxHitsConsidered;
+      //XHitSize.At(itrack, 0, 0) += bunch_of_hits.m_fill_index - Config::maxHitsConsidered;//this can be negative!
+      XHitSize.At(itrack, 0, 0) = std::min(int(bunch_of_hits.m_fill_index),int(Config::maxHitsConsidered));//fixme: not sure this is the desired behavior
     }
 
     // XXXX Hack to limit N_hits to maxHitsConsidered.

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -340,40 +340,40 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	  //outPar.At(n, 5, 0) = pz; //take this out as it is redundant
 
 	  if (Config::useSimpleJac==0 && i+1 != Config::Niter && r0 > 0 && fabs((r-r0)*invcurvature)>0.000000001)
-         {
-            //update derivatives on total distance for next step, where totalDistance+=r-r0
-            //now r0 depends on px and py
-            r0 = 1./r0;//WARNING, now r0 is r0inv (one less temporary)
+	  {
+	     //update derivatives on total distance for next step, where totalDistance+=r-r0
+	     //now r0 depends on px and py
+	     r0 = 1./r0;//WARNING, now r0 is r0inv (one less temporary)
 
 #ifdef DEBUG
-            std::cout << "r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt << std::endl;
+	     std::cout << "r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt << std::endl;
 #endif
 
-            //update derivative on D
-            dAPdx = -x*r0*invcurvature;
-            dAPdy = -y*r0*invcurvature;
-            dAPdpx = -(r-1./r0)*invcurvature*px*pt2inv;//weird, using r0 instead of 1./r0 improves things but it should be wrong since r0 in now r0inv
-            dAPdpy = -(r-1./r0)*invcurvature*py*pt2inv;//weird, using r0 instead of 1./r0 improves things but it should be wrong since r0 in now r0inv
-            //reduce temporary variables
-            //dxdx = 1 + k*dAPdx*(px*cosAP - py*sinAP);
-            //dydx = k*dAPdx*(py*cosAP + px*sinAP);
-            //dTDdx -= r0*(x*dxdx + y*dydx);
-            dTDdx -= r0*(x*(1 + k*dAPdx*(px*cosAP - py*sinAP)) + y*(k*dAPdx*(py*cosAP + px*sinAP)));
-            //reuse same temporary variables
-            //dxdy = k*dAPdy*(px*cosAP - py*sinAP);
-            //dydy = 1 + k*dAPdy*(py*cosAP + px*sinAP);
-            //dTDdy -= r0*(x*dxdy + y*dydy);
-            dTDdy -= r0*(x*(k*dAPdy*(px*cosAP - py*sinAP)) + y*(1 + k*dAPdy*(py*cosAP + px*sinAP)));
-            //dxdpx = k*(sinAP + px*cosAP*dAPdpx - py*sinAP*dAPdpx);
-            //dydpx = k*(py*cosAP*dAPdpx + 1. - cosAP + px*sinAP*dAPdpx);
-            //dTDdpx -= r0*(x*dxdpx + y*dydpx);
-            dTDdpx -= r0*(x*(k*(sinAP + px*cosAP*dAPdpx - py*sinAP*dAPdpx)) + y*(k*(py*cosAP*dAPdpx + 1. - cosAP + px*sinAP*dAPdpx)));
-            //dxdpy = k*(px*cosAP*dAPdpy - 1. + cosAP - py*sinAP*dAPdpy);
-            //dydpy = k*(sinAP + py*cosAP*dAPdpy + px*sinAP*dAPdpy);
-            //dTDdpy -= r0*(x*dxdpy + y*(dydpy);
-            dTDdpy -= r0*(x*(k*(px*cosAP*dAPdpy - 1. + cosAP - py*sinAP*dAPdpy)) + y*(k*(sinAP + py*cosAP*dAPdpy + px*sinAP*dAPdpy)));
+	     //update derivative on D
+	     dAPdx = -x*r0*invcurvature;
+	     dAPdy = -y*r0*invcurvature;
+	     dAPdpx = -(r-1./r0)*invcurvature*px*pt2inv;//weird, using r0 instead of 1./r0 improves things but it should be wrong since r0 in now r0inv
+	     dAPdpy = -(r-1./r0)*invcurvature*py*pt2inv;//weird, using r0 instead of 1./r0 improves things but it should be wrong since r0 in now r0inv
+	     //reduce temporary variables
+	     //dxdx = 1 + k*dAPdx*(px*cosAP - py*sinAP);
+	     //dydx = k*dAPdx*(py*cosAP + px*sinAP);
+	     //dTDdx -= r0*(x*dxdx + y*dydx);
+	     dTDdx -= r0*(x*(1 + k*dAPdx*(px*cosAP - py*sinAP)) + y*(k*dAPdx*(py*cosAP + px*sinAP)));
+	     //reuse same temporary variables
+	     //dxdy = k*dAPdy*(px*cosAP - py*sinAP);
+	     //dydy = 1 + k*dAPdy*(py*cosAP + px*sinAP);
+	     //dTDdy -= r0*(x*dxdy + y*dydy);
+	     dTDdy -= r0*(x*(k*dAPdy*(px*cosAP - py*sinAP)) + y*(1 + k*dAPdy*(py*cosAP + px*sinAP)));
+	     //dxdpx = k*(sinAP + px*cosAP*dAPdpx - py*sinAP*dAPdpx);
+	     //dydpx = k*(py*cosAP*dAPdpx + 1. - cosAP + px*sinAP*dAPdpx);
+	     //dTDdpx -= r0*(x*dxdpx + y*dydpx);
+	     dTDdpx -= r0*(x*(k*(sinAP + px*cosAP*dAPdpx - py*sinAP*dAPdpx)) + y*(k*(py*cosAP*dAPdpx + 1. - cosAP + px*sinAP*dAPdpx)));
+	     //dxdpy = k*(px*cosAP*dAPdpy - 1. + cosAP - py*sinAP*dAPdpy);
+	     //dydpy = k*(sinAP + py*cosAP*dAPdpy + px*sinAP*dAPdpy);
+	     //dTDdpy -= r0*(x*dxdpy + y*(dydpy);
+	     dTDdpy -= r0*(x*(k*(px*cosAP*dAPdpy - 1. + cosAP - py*sinAP*dAPdpy)) + y*(k*(sinAP + py*cosAP*dAPdpy + px*sinAP*dAPdpy)));
 
-         }
+	  }
 	  
 #ifdef DEBUG
 	  std::cout << "iteration end, dump parameters" << std::endl;
@@ -688,15 +688,50 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         jacCurvProp(n,4,4) = (v11*v21 + v12*v22 + v13*v23);
 
 #ifdef DEBUG
-      std::cout << "jacCurvProp" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,0,0),jacCurvProp(n,0,1),jacCurvProp(n,0,2),jacCurvProp(n,0,3),jacCurvProp(n,0,4),jacCurvProp(n,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,1,0),jacCurvProp(n,1,1),jacCurvProp(n,1,2),jacCurvProp(n,1,3),jacCurvProp(n,1,4),jacCurvProp(n,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,2,0),jacCurvProp(n,2,1),jacCurvProp(n,2,2),jacCurvProp(n,2,3),jacCurvProp(n,2,4),jacCurvProp(n,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,3,0),jacCurvProp(n,3,1),jacCurvProp(n,3,2),jacCurvProp(n,3,3),jacCurvProp(n,3,4),jacCurvProp(n,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,4,0),jacCurvProp(n,4,1),jacCurvProp(n,4,2),jacCurvProp(n,4,3),jacCurvProp(n,4,4),jacCurvProp(n,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,5,0),jacCurvProp(n,5,1),jacCurvProp(n,5,2),jacCurvProp(n,5,3),jacCurvProp(n,5,4),jacCurvProp(n,5,5));
+	std::cout << "jacCurvProp" << std::endl;
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,0,0),jacCurvProp(n,0,1),jacCurvProp(n,0,2),jacCurvProp(n,0,3),jacCurvProp(n,0,4),jacCurvProp(n,0,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,1,0),jacCurvProp(n,1,1),jacCurvProp(n,1,2),jacCurvProp(n,1,3),jacCurvProp(n,1,4),jacCurvProp(n,1,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,2,0),jacCurvProp(n,2,1),jacCurvProp(n,2,2),jacCurvProp(n,2,3),jacCurvProp(n,2,4),jacCurvProp(n,2,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,3,0),jacCurvProp(n,3,1),jacCurvProp(n,3,2),jacCurvProp(n,3,3),jacCurvProp(n,3,4),jacCurvProp(n,3,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,4,0),jacCurvProp(n,4,1),jacCurvProp(n,4,2),jacCurvProp(n,4,3),jacCurvProp(n,4,4),jacCurvProp(n,4,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,5,0),jacCurvProp(n,5,1),jacCurvProp(n,5,2),jacCurvProp(n,5,3),jacCurvProp(n,5,4),jacCurvProp(n,5,5));
 #endif
-        
+
+	MPlexLL temp5;
+	MultHelixPropFull(jacCartToCurv, rotateCartCa2Cu, temp5);
+#ifdef DEBUG
+	std::cout << "rotated jacCartToCurv" << std::endl;
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,0,0),temp5(n,0,1),temp5(n,0,2),temp5(n,0,3),temp5(n,0,4),temp5(n,0,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,1,0),temp5(n,1,1),temp5(n,1,2),temp5(n,1,3),temp5(n,1,4),temp5(n,1,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,2,0),temp5(n,2,1),temp5(n,2,2),temp5(n,2,3),temp5(n,2,4),temp5(n,2,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,3,0),temp5(n,3,1),temp5(n,3,2),temp5(n,3,3),temp5(n,3,4),temp5(n,3,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,4,0),temp5(n,4,1),temp5(n,4,2),temp5(n,4,3),temp5(n,4,4),temp5(n,4,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,5,0),temp5(n,5,1),temp5(n,5,2),temp5(n,5,3),temp5(n,5,4),temp5(n,5,5));
+#endif
+	MPlexLL temp6;
+	MultHelixPropFull(rotateCartCu2Ca, jacCurvToCart, temp6);
+#ifdef DEBUG
+	std::cout << "rotated jacCurvToCart" << std::endl;
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,0,0),temp6(n,0,1),temp6(n,0,2),temp6(n,0,3),temp6(n,0,4),temp6(n,0,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,1,0),temp6(n,1,1),temp6(n,1,2),temp6(n,1,3),temp6(n,1,4),temp6(n,1,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,2,0),temp6(n,2,1),temp6(n,2,2),temp6(n,2,3),temp6(n,2,4),temp6(n,2,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,3,0),temp6(n,3,1),temp6(n,3,2),temp6(n,3,3),temp6(n,3,4),temp6(n,3,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,4,0),temp6(n,4,1),temp6(n,4,2),temp6(n,4,3),temp6(n,4,4),temp6(n,4,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,5,0),temp6(n,5,1),temp6(n,5,2),temp6(n,5,3),temp6(n,5,4),temp6(n,5,5));
+#endif
+	MPlexLL temp7;
+	MultHelixPropFull(jacCurvProp, temp5, temp7);
+	MultHelixPropFull(temp6, temp7, errorProp);
+#ifdef DEBUG
+	std::cout << "jacobian iterative" << std::endl;
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
+	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+#endif
+
       } else if (Config::useSimpleJac) { 
 	//assume total path length s as given and with no uncertainty
 	float p = pt2 + pzin*pzin;
@@ -758,55 +793,15 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
       }
 
 #ifdef DEBUG
-      if (Config::useCurvJac==0) {
-	std::cout << "jacobian iterative" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
-      }
+      std::cout << "jacobian iterative" << std::endl;
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
+      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
 #endif
     }
-
-  if (Config::useCurvJac) {    
-    MPlexLL temp;
-    MultHelixPropFull(jacCartToCurv, rotateCartCa2Cu, temp);
-#ifdef DEBUG
-      std::cout << "rotated jacCartToCurv" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,0,0),temp(0,0,1),temp(0,0,2),temp(0,0,3),temp(0,0,4),temp(0,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,1,0),temp(0,1,1),temp(0,1,2),temp(0,1,3),temp(0,1,4),temp(0,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,2,0),temp(0,2,1),temp(0,2,2),temp(0,2,3),temp(0,2,4),temp(0,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,3,0),temp(0,3,1),temp(0,3,2),temp(0,3,3),temp(0,3,4),temp(0,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,4,0),temp(0,4,1),temp(0,4,2),temp(0,4,3),temp(0,4,4),temp(0,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp(0,5,0),temp(0,5,1),temp(0,5,2),temp(0,5,3),temp(0,5,4),temp(0,5,5));
-#endif
-    MPlexLL temp2;
-    MultHelixPropFull(rotateCartCu2Ca, jacCurvToCart, temp2);
-#ifdef DEBUG
-      std::cout << "rotated jacCurvToCart" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,0,0),temp2(0,0,1),temp2(0,0,2),temp2(0,0,3),temp2(0,0,4),temp2(0,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,1,0),temp2(0,1,1),temp2(0,1,2),temp2(0,1,3),temp2(0,1,4),temp2(0,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,2,0),temp2(0,2,1),temp2(0,2,2),temp2(0,2,3),temp2(0,2,4),temp2(0,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,3,0),temp2(0,3,1),temp2(0,3,2),temp2(0,3,3),temp2(0,3,4),temp2(0,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,4,0),temp2(0,4,1),temp2(0,4,2),temp2(0,4,3),temp2(0,4,4),temp2(0,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", temp2(0,5,0),temp2(0,5,1),temp2(0,5,2),temp2(0,5,3),temp2(0,5,4),temp2(0,5,5));
-#endif
-    MPlexLL temp3;
-    MultHelixPropFull(jacCurvProp, temp, temp3);
-    MultHelixPropFull(temp2, temp3, errorProp);
-#ifdef DEBUG
-      std::cout << "jacobian iterative" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,0,0),errorProp(0,0,1),errorProp(0,0,2),errorProp(0,0,3),errorProp(0,0,4),errorProp(0,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,1,0),errorProp(0,1,1),errorProp(0,1,2),errorProp(0,1,3),errorProp(0,1,4),errorProp(0,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,2,0),errorProp(0,2,1),errorProp(0,2,2),errorProp(0,2,3),errorProp(0,2,4),errorProp(0,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,3,0),errorProp(0,3,1),errorProp(0,3,2),errorProp(0,3,3),errorProp(0,3,4),errorProp(0,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,4,0),errorProp(0,4,1),errorProp(0,4,2),errorProp(0,4,3),errorProp(0,4,4),errorProp(0,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(0,5,0),errorProp(0,5,1),errorProp(0,5,2),errorProp(0,5,3),errorProp(0,5,4),errorProp(0,5,5));
-#endif
-  }
-
 }
 
 void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& outPar, const MPlexQF &msRad, MPlexLL& errorProp) {

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -837,7 +837,7 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
     {
       const float& xin  = inPar.ConstAt(n, 0, 0);
       const float& yin  = inPar.ConstAt(n, 1, 0);
-      const float& zin  = inPar.ConstAt(0, 2, 0);
+      const float& zin  = inPar.ConstAt(n, 2, 0);
       const float& pxin = inPar.ConstAt(n, 3, 0);
       const float& pyin = inPar.ConstAt(n, 4, 0);
       const float& pzin = inPar.ConstAt(n, 5, 0);

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -236,17 +236,6 @@ bool has_suffix(const std::string &str, const std::string &suffix)
            str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
-void usage_and_die(const char* name)
-{
-  fprintf(stderr,
-          "Usage:\n"
-          "  %s                  --> runs simulation between events\n"
-          "  %s write [filename] --> runs simulation only, outputs events to file\n"
-          "  %s read  [filename] --> runs reco only, reads events from file\n"
-          "Default filename is \"simtracks.bin\".\n", name, name, name);
-  exit(1);
-}
-
 void next_arg_or_die(lStr_t& args, lStr_i& i, bool allow_single_minus=false)
 {
   lStr_i j = i;

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -348,6 +348,11 @@ int main(int argc, const char *argv[])
     {
       g_operation = "read";
     }
+    else if(*i == "--file-name")
+    {
+      next_arg_or_die(mArgs, i);
+      g_file_name = *i;
+    }
     else
     {
       fprintf(stderr, "Error: Unknown option/argument '%s'.\n", i->c_str());

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -130,8 +130,11 @@ void test_standard()
          MPT_SIZE, Config::numThreadsSimulation, Config::numThreadsFinder);
   printf("  sizeof(Track)=%zu, sizeof(Hit)=%zu, sizeof(SVector3)=%zu, sizeof(SMatrixSym33)=%zu, sizeof(MCHitInfo)=%zu\n",
          sizeof(Track), sizeof(Hit), sizeof(SVector3), sizeof(SMatrixSym33), sizeof(MCHitInfo));
-  if (Config::useCMSGeom) printf ("Using CMS-like geometry \n");
-  else printf ("Using 4-cm spacing geometry \n");
+  if (Config::useCMSGeom) {
+    printf ("Using CMS-like geometry ");
+    if (Config::readCmsswSeeds) printf ("with CMSSW seeds \n");
+    else printf ("with MC-truth seeds \n");
+  } else printf ("Using 4-cm spacing geometry \n");
 
   if (g_operation == "write") {
     generate_and_save_tracks();
@@ -283,6 +286,7 @@ int main(int argc, const char *argv[])
         "  --cloner-single-thread   do not spawn extra cloning thread (def: %s)\n"
         "  --best-out-of   <num>    run track finding num times, report best time (def: %d)\n"
 	"  --cms-geom               use cms-like geometry (def: %i)\n"
+	"  --cmssw-seeds            take seeds from CMSSW (def: %i)\n"
 	"  --write                  write simulation to file and exit\n"
 	"  --read                   read simulation from file\n"
 	"  --file-name              file name for write/read (def: %s)\n"
@@ -292,6 +296,7 @@ int main(int argc, const char *argv[])
         Config::clonerUseSingleThread ? "true" : "false",
         Config::finderReportBestOutOfN,
 	Config::useCMSGeom,
+	Config::readCmsswSeeds,
 	g_file_name.c_str()
       );
       exit(0);
@@ -339,6 +344,10 @@ int main(int argc, const char *argv[])
     else if(*i == "--cms-geom")
     {
       Config::useCMSGeom = true;
+    }
+    else if(*i == "--cmssw-seeds")
+    {
+      Config::readCmsswSeeds = true;
     }
     else if(*i == "--write")
     {


### PR DESCRIPTION
- rework of kalman calculations (both in Matriplex and SMatrix), to use hit coordinates on tangent plane and "polar" coordinates for kalman update
- add curvilinear jacobian (as cmssw), not used and not optimized
- go back to iterative jacobian by default
- add option to read seed collection from cmssw input "readCmsswSeeds"
- protections against non finite eta values
- fix small issue with wrapping in SelectHitRanges causing small inconsistency in output for different MPT_SIZE
- update of Math/MatrixRepresentationsStatic.h from recent ROOT version, looks like SMatrix has now reduced the object size as well
- other minor fixes
