### PR TITLE
move tbb and omp thread init out of event loop

### DIFF
--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -254,6 +254,14 @@ void test_standard()
   std::cerr << "###### Total GPU time: " << dtime() - total_gpu_time << " ######\n";
 
 #else
+  // MT: task_scheduler_init::automatic doesn't really work (segv!) + we don't
+  // know what to do for non-tbb cases.
+  // tbb::task_scheduler_init tbb_init(Config::numThreadsFinder != 0 ?
+  //                                   Config::numThreadsFinder :
+  //                                   tbb::task_scheduler_init::automatic);
+  tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
+  omp_set_num_threads(Config::numThreadsFinder);
+
   for (int evt = 1; evt <= Config::nEvents; ++evt)
   {
     printf("\n");
@@ -274,13 +282,6 @@ void test_standard()
       ev.Simulate();
       ev.resetLayerHitMap(true);
     }
-    // MT: task_scheduler_init::automatic doesn't really work (segv!) + we don't
-    // know what to do for non-tbb cases.
-    // tbb::task_scheduler_init tbb_init(Config::numThreadsFinder != 0 ?
-    //                                   Config::numThreadsFinder :
-    //                                   tbb::task_scheduler_init::automatic);
-    tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
-    omp_set_num_threads(Config::numThreadsFinder);
 
     plex_tracks.resize(ev.simTracks_.size());
 


### PR DESCRIPTION
One of the late additions to pr#40 introduced a large regression, apparently tbb::task_scheduler_init is expensive (and randomly expensive) even when the number of threads doesn't change.  This PR moves the TBB and OMP thread initializations out of the event loop.  Since this is a small, specific point fix I'll approve the PR myself.  Supporting plots etc. are in /home/dsr/mictest-mt/2016-04-20 on phiphi.