### PR TITLE
Debug cleanup

### DIFF
--- a/Debug.h
+++ b/Debug.h
@@ -1,10 +1,17 @@
-//#define DEBUG
+#ifndef _debug_
+#define _debug_
 #ifdef DEBUG
-#define dprint(x) if (debug) std::cout << x << std::endl
-#define dcall(x)  if (debug) { x; }
-#define dprintf(...) if (debug) { printf(__VA_ARGS__); }
+#include <mutex>
 
-namespace { bool debug = true; } // default value, can be overridden locally
+#define dmutex std::lock_guard<std::mutex> dlock(debug_mutex)
+#define dprint(x) if (debug) { dmutex; std::cout << x << std::endl; }
+#define dcall(x)  if (debug) { dmutex; x; }
+#define dprintf(...) if (debug) { dmutex; printf(__VA_ARGS__); }
+
+namespace { 
+  bool debug = true; // default, can be overridden locally
+  std::mutex debug_mutex;
+}
 
 static void print(const TrackState& s)
 {
@@ -46,4 +53,5 @@ static void print(std::string label, const MeasurementState& s)
 #define dprint(x) (void(0))
 #define dcall(x) (void(0))
 #define dprintf(...) (void(0))
+#endif
 #endif

--- a/Debug.h
+++ b/Debug.h
@@ -2,6 +2,9 @@
 #ifdef DEBUG
 #define dprint(x) if (debug) std::cout << x << std::endl
 #define dcall(x)  if (debug) { x; }
+#define dprintf(...) if (debug) { printf(__VA_ARGS__); }
+
+namespace { bool debug = true; } // default value, can be overridden locally
 
 static void print(const TrackState& s)
 {
@@ -42,4 +45,5 @@ static void print(std::string label, const MeasurementState& s)
 #else
 #define dprint(x) (void(0))
 #define dcall(x) (void(0))
+#define dprintf(...) (void(0))
 #endif

--- a/Debug.h
+++ b/Debug.h
@@ -1,6 +1,39 @@
 #ifndef _debug_
 #define _debug_
 #ifdef DEBUG
+/*
+  Usage: DEBUG must be defined before this header file is included, typically
+
+  #define DEBUG
+  #include "Debug.h"
+
+  This defines macros dprint(), dcall() and dprintf();
+  dprint(x) is equivalent to std::cout << x << std::endl;
+    example: dprint("Hits in layer=" << ilayer);
+
+  dcall(x) simply calls x
+    example: dcall(pre_prop_print(ilay, mkfp));
+
+  dprintf(x) is equivalent to printf(x)
+    example: dprintf("Bad label for simtrack %d -- %d\n", itrack, track.label());
+
+  All printouts are also controlled by a bool variable "debug"
+  bool debug = true; is declared as a file global in an anonymous
+  namespace, and thus can be overridden within any interior scope
+  as needed, so one could change the global to false and only set
+  a local to true within certain scopes.
+
+  All are protected by a file scope mutex to avoid mixed printouts.
+  This mutex can also be acquired within a block via dmutex_guard:
+
+  if (debug) {
+    dmutex_guard;
+    [do complicated stuff]
+  }
+
+  The mutex is not reentrant, so avoid using dprint et al. within a scope
+  where the mutex has already been acquired, as doing so will deadlock.
+ */
 #include <mutex>
 
 #define dmutex_guard std::lock_guard<std::mutex> dlock(debug_mutex)

--- a/Debug.h
+++ b/Debug.h
@@ -3,10 +3,10 @@
 #ifdef DEBUG
 #include <mutex>
 
-#define dmutex std::lock_guard<std::mutex> dlock(debug_mutex)
-#define dprint(x) if (debug) { dmutex; std::cout << x << std::endl; }
-#define dcall(x)  if (debug) { dmutex; x; }
-#define dprintf(...) if (debug) { dmutex; printf(__VA_ARGS__); }
+#define dmutex_guard std::lock_guard<std::mutex> dlock(debug_mutex)
+#define dprint(x) if (debug) { dmutex_guard; std::cout << x << std::endl; }
+#define dcall(x)  if (debug) { dmutex_guard; x; }
+#define dprintf(...) if (debug) { dmutex_guard; printf(__VA_ARGS__); }
 
 namespace { 
   bool debug = true; // default, can be overridden locally

--- a/Event.cc
+++ b/Event.cc
@@ -164,11 +164,11 @@ void Event::Segment()
           lastPhiIdxFound+=phiBinSize;
         }
 #ifdef DEBUG
-        if ((debug) && (phiBinSize !=0)) printf("ilayer: %1u etabin: %1u phibin: %2u first: %2u last: %2u \n", 
-                                                ilayer, etabin, phibin, 
-                                                segmentMap_[ilayer][etabin][phibin].first, 
-                                                segmentMap_[ilayer][etabin][phibin].second+segmentMap_[ilayer][etabin][phibin].first
-                                                );
+        if ((debug) && (phiBinSize !=0)) dprintf("ilayer: %1u etabin: %1u phibin: %2u first: %2u last: %2u \n", 
+                                                 ilayer, etabin, phibin, 
+                                                 segmentMap_[ilayer][etabin][phibin].first, 
+                                                 segmentMap_[ilayer][etabin][phibin].second+segmentMap_[ilayer][etabin][phibin].first
+                                                 );
 #endif
       } // end loop over storing phi index
     } // end loop over storing eta index
@@ -200,6 +200,7 @@ void Event::Segment()
 
 #ifdef DEBUG
   for (int ilayer = 0; ilayer < Config::nLayers; ilayer++) {
+    dmutex;
     int etahitstotal = 0;
     for (int etabin = 0; etabin < Config::nEtaPart; etabin++){
       int etahits = segmentMap_[ilayer][etabin][Config::nPhiPart-1].first + segmentMap_[ilayer][etabin][Config::nPhiPart-1].second - segmentMap_[ilayer][etabin][0].first;

--- a/Event.cc
+++ b/Event.cc
@@ -200,7 +200,7 @@ void Event::Segment()
 
 #ifdef DEBUG
   for (int ilayer = 0; ilayer < Config::nLayers; ilayer++) {
-    dmutex;
+    dmutex_guard;
     int etahitstotal = 0;
     for (int etabin = 0; etabin < Config::nEtaPart; etabin++){
       int etahits = segmentMap_[ilayer][etabin][Config::nPhiPart-1].first + segmentMap_[ilayer][etabin][Config::nPhiPart-1].second - segmentMap_[ilayer][etabin][0].first;

--- a/Event.cc
+++ b/Event.cc
@@ -6,6 +6,8 @@
 #include "fittest.h"
 #include "BinInfoUtils.h"
 #include "ConformalUtils.h"
+
+//#define DEBUG
 #include "Debug.h"
 
 #ifdef TBB

--- a/KalmanUtils.cc
+++ b/KalmanUtils.cc
@@ -1,4 +1,5 @@
 #include "KalmanUtils.h"
+//#define DEBUG
 #include "Debug.h"
 
 static const SMatrix36 projMatrix  = ROOT::Math::SMatrixIdentity();

--- a/KalmanUtils.cc
+++ b/KalmanUtils.cc
@@ -126,7 +126,7 @@ TrackState updateParameters(const TrackState& propagatedState, const Measurement
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     std::cout << "\n updateParameters \n" << std::endl << "propErr" << std::endl;
     dumpMatrix(propagatedState.errors);
     std::cout << "residual: " << res[0] << " " << res[1] << std::endl

--- a/KalmanUtils.cc
+++ b/KalmanUtils.cc
@@ -126,6 +126,7 @@ TrackState updateParameters(const TrackState& propagatedState, const Measurement
 
 #ifdef DEBUG
   if (debug) {
+    dmutex;
     std::cout << "\n updateParameters \n" << std::endl << "propErr" << std::endl;
     dumpMatrix(propagatedState.errors);
     std::cout << "residual: " << res[0] << " " << res[1] << std::endl

--- a/Propagation.cc
+++ b/Propagation.cc
@@ -413,7 +413,7 @@ TrackState propagateHelixToR(TrackState inputState, float r) {
     if ( i == (Config::Niter-1) && std::abs(r-hsout.r0) > tolerance) {
 #ifdef DEBUG
       if (debug) { // common condition when fit fails to converge
-        dmutex;
+        dmutex_guard;
         std::cerr << __FILE__ << ":" << __LINE__ 
                   << ": failed to converge in propagateHelixToR() after " << (i+1) << " iterations, r = "
                   << r 

--- a/Propagation.cc
+++ b/Propagation.cc
@@ -78,8 +78,8 @@ struct HelixState {
     dTDdpy = 0.;
   }
 
-  void updateHelix(float distance, bool updateDeriv, bool dump = false);
-  void propagateErrors(const HelixState& in, float totalDistance, bool dump = false);
+  void updateHelix(float distance, bool updateDeriv, bool debug = false);
+  void propagateErrors(const HelixState& in, float totalDistance, bool debug = false);
 
   float x, y, z, px, py, pz;
   float k, pt, pt2, pt3, r0, curvature, ctgTheta;
@@ -142,8 +142,8 @@ void HelixState::updateHelix(float distance, bool updateDeriv, bool debug)
     dTDdpy -= r0inv*(x*dxdpy + y*dydpy);
   }
 
-    dprint(par.At(0) << " " << par.At(1) << " " << par.At(2) << std::endl
-        << par.At(3) << " " << par.At(4) << " " << par.At(5));
+  dprint(par.At(0) << " " << par.At(1) << " " << par.At(2) << std::endl
+      << par.At(3) << " " << par.At(4) << " " << par.At(5));
 }
 
 void HelixState::propagateErrors(const HelixState& in, float totalDistance, bool debug)
@@ -220,14 +220,10 @@ void HelixState::propagateErrors(const HelixState& in, float totalDistance, bool
 
   state.errors=ROOT::Math::Similarity(errorProp,state.errors);
 
-#ifdef DEBUG
-  if (debug) {
-    std::cout << "errorProp" << std::endl;
-    dumpMatrix(errorProp);
-    std::cout << "result.errors" << std::endl;
-    dumpMatrix(state.errors);
-  }
-#endif
+  dprint("errorProp");
+  dcall(dumpMatrix(errorProp));
+  dprint("result.errors");
+  dcall(dumpMatrix(state.errors));
 }
 
 // helix propagation in steps along helix trajectory, several versions
@@ -417,6 +413,7 @@ TrackState propagateHelixToR(TrackState inputState, float r) {
     if ( i == (Config::Niter-1) && std::abs(r-hsout.r0) > tolerance) {
 #ifdef DEBUG
       if (debug) { // common condition when fit fails to converge
+        dmutex;
         std::cerr << __FILE__ << ":" << __LINE__ 
                   << ": failed to converge in propagateHelixToR() after " << (i+1) << " iterations, r = "
                   << r 
@@ -438,7 +435,7 @@ TrackState propagateHelixToR(TrackState inputState, float r) {
 //2. there are 2 numerical solutions, 3. need to propagate uncertainties throgh the 2nd order equation
 TrackState propagateHelixToR_test(TrackState& inputState, float r) {
 
-  bool dump = false;
+  bool debug = false;
 
   int charge = inputState.charge;
 
@@ -455,7 +452,7 @@ TrackState propagateHelixToR_test(TrackState& inputState, float r) {
   //p=0.3Br => r=p/(0.3*B)
   float k=charge*100./(-Config::sol*Config::Bfield);
   float curvature = pt*k;//in cm
-  if (dump) std::cout << "curvature=" << curvature << std::endl;
+  dprint("curvature=" << curvature);
   float ctgTheta=pzin/pt;
 
   float r0in = sqrt(xin*xin+yin*yin);
@@ -486,7 +483,7 @@ TrackState propagateHelixToR_test(TrackState& inputState, float r) {
   float aeq = k*k*(pt2+(pxin*yin-pyin*xin)/k);
   float xeq1 = (-beq + sqrt(beq*beq-4*aeq*ceq))/(2*aeq);
   float xeq2 = (-beq - sqrt(beq*beq-4*aeq*ceq))/(2*aeq);
-  if (dump) std::cout << "xeq1=" << xeq1 << " xeq2=" << xeq2 << std::endl;
+  dprint("xeq1=" << xeq1 << " xeq2=" << xeq2);
   //test//
 
   float totalAngPath=xeq1;
@@ -513,7 +510,7 @@ TrackState propagateHelixToR_test(TrackState& inputState, float r) {
   par.At(4) = pyin*cosTP+pxin*sinTP;
   par.At(5) = pzin;
 
-  if (dump) std::cout << "TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(par.At(0)*par.At(0)+par.At(1)*par.At(1)) << std::endl;
+  dprint("TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(par.At(0)*par.At(0)+par.At(1)*par.At(1)));
 
   float dCdpx = k*pxin/pt;
   float dCdpy = k*pyin/pt;
@@ -586,19 +583,15 @@ TrackState propagateHelixToR_test(TrackState& inputState, float r) {
   errorProp(4,3)=dpydpx;
   errorProp(4,4)=dpydpy;
 
-  if (dump) {
-    std::cout << "errorProp" << std::endl;
-    dumpMatrix(errorProp);
-  }
+  dprint("errorProp");
+  dcall(dumpMatrix(errorProp));
 
   TrackState result;
   result.parameters=par;
   result.errors=ROOT::Math::Similarity(errorProp,err);
   result.charge = charge;
-  if (dump) {
-    std::cout << "result.errors" << std::endl;
-    dumpMatrix(result.errors);
-  }
+  dprint("result.errors");
+  dcall(dumpMatrix(result.errors));
   return result;
 
 }
@@ -609,7 +602,7 @@ TrackState propagateHelixToR_test(TrackState& inputState, float r) {
 
 void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& result)
 {
-   const bool dump = false;
+   const bool debug = false;
 
    float xin = inputState.parameters.At(0);
    float yin = inputState.parameters.At(1);
@@ -625,11 +618,11 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
    SVector6& par = result.parameters;
    SMatrixSym66& err = result.errors;
 
+   dprint("attempt propagation from r=" << r0in << " to r=" << r << std::endl
+           << xin << " y=" << yin << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inputState.charge);
 #ifdef DEBUG
-   if (dump) std::cout << "attempt propagation from r=" << r0in << " to r=" << r << std::endl;
-   if (dump) std::cout << "x=" << xin << " y=" << yin << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inputState.charge << std::endl;
    if ((r0in-r)>=0) {
-      if (dump) std::cout << "target radius same or smaller than starting point, returning input" << std::endl;
+      dprint("target radius same or smaller than starting point, returning input");
       return;
    }
 #endif
@@ -641,7 +634,7 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
    //p=0.3Br => r=p/(0.3*B)
    float k=inputState.charge*100./(-Config::sol*Config::Bfield);
    float invcurvature = 1./(pt*k);//in 1./cm
-   if (dump) std::cout << "curvature=" << 1./invcurvature << std::endl;
+   dprint("curvature=" << 1./invcurvature);
    float ctgTheta=pzin*ptinv;
    //variables to be updated at each iterations
    //derivatives initialized to value for first iteration, i.e. distance = r-r0in
@@ -662,33 +655,25 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
  
    for (int i = 0; i < Config::Niter; ++i)
    {
-#ifdef DEBUG
-      if (dump) std::cout << "propagation iteration #" << i << std::endl;
-#endif
+      dprint("propagation iteration #" << i);
       float x = par.At(0);
       float y = par.At(1);
       float px = par.At(3);
       float py = par.At(4);
 
       float r0 = sqrt(par.At(0)*par.At(0)+par.At(1)*par.At(1));
+      dprint("r0=" << r0 << " pt=" << pt);
 #ifdef DEBUG
-      if (dump) std::cout << "r0=" << r0 << " pt=" << pt << std::endl;
-      if (dump) {
-         if (r==r0) {
-            std::cout << "distance = 0 at iteration=" << i << std::endl;
-            break;
-         }
+       if (r==r0) {
+          dprint("distance = 0 at iteration=" << i);
+          break;
       }
 #endif
       float distance = r-r0;
       totalDistance += distance;
-#ifdef DEBUG
-      if (dump) std::cout << "distance=" << distance << std::endl;
-#endif
+      dprint("distance=" << distance);
       float angPath = distance*invcurvature;
-#ifdef DEBUG
-      if (dump) std::cout << "angPath=" << angPath << std::endl;
-#endif
+      dprint("angPath=" << angPath);
       // cosAP=cos(angPath);
       // sinAP=sin(angPath);
       sincos4(angPath, sinAP, cosAP);
@@ -707,9 +692,7 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
          //update derivatives on total distance for next step, where totalDistance+=r-r0
          //now r0 depends on px and py
          r0 = 1./r0;//WARNING, now r0 is r0inv (one less temporary)
-#ifdef DEBUG
-         if (dump) std::cout << "r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt << std::endl;
-#endif
+         dprint("r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt);
          //update derivative on D
          dAPdx  = -x*r0*invcurvature;
          dAPdy  = -y*r0*invcurvature;
@@ -734,18 +717,14 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
          //dTDdpy -= r0*(x*dxdpy + y*(k*dydpy);
          dTDdpy -= r0*(x*(k*(px*cosAP*dAPdpy - 1. + cosAP - py*sinAP*dAPdpy)) + y*(k*(sinAP + py*cosAP*dAPdpy + px*sinAP*dAPdpy)));
       }
-#ifdef DEBUG
-      if (dump) std::cout << par.At(0) << " " << par.At(1) << " " << par.At(2) << std::endl;
-      if (dump) std::cout << par.At(3) << " " << par.At(4) << " " << par.At(5) << std::endl;
-#endif
+      dprint(par.At(0) << " " << par.At(1) << " " << par.At(2) << std::endl
+          << par.At(3) << " " << par.At(4) << " " << par.At(5));
    }
    float totalAngPath=totalDistance*invcurvature;
    float& TD=totalDistance;
    float& TP=totalAngPath;
    float& iC=invcurvature;
-#ifdef DEBUG
-   if (dump) std::cout << "TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(par.At(0)*par.At(0)+par.At(1)*par.At(1)) << std::endl;
-#endif
+   dprint("TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(par.At(0)*par.At(0)+par.At(1)*par.At(1)));
    float dCdpx = k*pxin*ptinv;
    float dCdpy = k*pyin*ptinv;
    float dTPdx = dTDdx*iC;
@@ -789,14 +768,10 @@ void propagateHelixToR_fewerTemps(TrackState& inputState, float r, TrackState& r
    errorProp(4,3) = +sinTP - dTPdpx*(pyin*sinTP - pxin*cosTP);//dpydpx;
    errorProp(4,4) = +cosTP - dTPdpy*(pyin*sinTP - pxin*cosTP);//dpydpy;
    result.errors=ROOT::Math::Similarity(errorProp,err);
-#ifdef DEBUG
-   if (dump) {
-      std::cout << "errorProp" << std::endl;
-      dumpMatrix(errorProp);
-      std::cout << "result.errors" << std::endl;
-      dumpMatrix(result.errors);
-   }
-#endif
+   dprint("errorProp");
+   dcall(dumpMatrix(errorProp));
+   dprint("result.errors");
+   dcall(dumpMatrix(result.errors));
    /*
      if (fabs(sqrt(par[0]*par[0]+par[1]*par[1])-r)>0.0001) {
      std::cout << "DID NOT GET TO R, dR=" << fabs(sqrt(par[0]*par[0]+par[1]*par[1])-r)

--- a/Propagation.cc
+++ b/Propagation.cc
@@ -1,4 +1,5 @@
 #include "Propagation.h"
+//#define DEBUG
 #include "Debug.h"
 
 const double tolerance = 0.001;

--- a/Simulation.cc
+++ b/Simulation.cc
@@ -1,6 +1,7 @@
 #include <cmath>
 
 #include "Simulation.h"
+//#define DEBUG
 #include "Debug.h"
 
 //#define SOLID_SMEAR

--- a/Simulation.cc
+++ b/Simulation.cc
@@ -262,7 +262,7 @@ void setupTrackByToyMC(SVector3& pos, SVector3& mom, SMatrixSym66& covtrk,
       UVector3 hit_point(hitX,hitY,hitZ);
       const auto theHitSolid = geom.InsideWhat(hit_point);
       if ( ! theHitSolid ) {
-        dmutex;
+        dmutex_guard;
         std::cerr << __FILE__ << ":" << __LINE__ << ": failed to find solid AFTER scatter+smear." << std::endl;
         std::cerr << "itrack = " << itrack << ", ihit = " << ihit << ", r = " << sqrt(hitX*hitX + hitY*hitY) << ", r*4cm = " << 4*ihit << ", phi = " << getPhi(hitX,hitY) << std::endl;
         std::cerr << "initX = " << initX << ", initY = " << initY << ", initZ = " << initZ << std::endl;

--- a/Simulation.cc
+++ b/Simulation.cc
@@ -262,6 +262,7 @@ void setupTrackByToyMC(SVector3& pos, SVector3& mom, SMatrixSym66& covtrk,
       UVector3 hit_point(hitX,hitY,hitZ);
       const auto theHitSolid = geom.InsideWhat(hit_point);
       if ( ! theHitSolid ) {
+        dmutex;
         std::cerr << __FILE__ << ":" << __LINE__ << ": failed to find solid AFTER scatter+smear." << std::endl;
         std::cerr << "itrack = " << itrack << ", ihit = " << ihit << ", r = " << sqrt(hitX*hitX + hitY*hitY) << ", r*4cm = " << 4*ihit << ", phi = " << getPhi(hitX,hitY) << std::endl;
         std::cerr << "initX = " << initX << ", initY = " << initY << ", initZ = " << initZ << std::endl;

--- a/Track.cc
+++ b/Track.cc
@@ -1,4 +1,5 @@
 #include "Track.h"
+//#define DEBUG
 #include "Debug.h"
 
 // find the simtrack that provided the most hits

--- a/fittest.cc
+++ b/fittest.cc
@@ -3,6 +3,7 @@
 #include "KalmanUtils.h"
 #include "Propagation.h"
 #include "ConformalUtils.h"
+//#define DEBUG
 #include "Debug.h"
 
 #ifdef TBB

--- a/fittest.cc
+++ b/fittest.cc
@@ -81,17 +81,13 @@ void fitTrack(const Track & trk, const TrackExtra& trkextra, int itrack, Event& 
     }
 #endif
 
-#ifdef DEBUG
-    if (debug) {
-      std::cout << "processing hit: " << hit.mcHitID() << std::endl
-                << "hitR, propR, updR = " << hit.r() << ", " 
-                << Mag(propPos) << ", " << Mag(updPos) << std::endl << std::endl;
+    dprint("processing hit: " << hit.mcHitID() << std::endl
+              << "hitR, propR, updR = " << hit.r() << ", " 
+              << Mag(propPos) << ", " << Mag(updPos) << std::endl);
 
-      print("measState", measState);
-      print("propState", propState);
-      print("updatedState", updatedState);
-    }
-#endif
+    dcall(print("measState", measState));
+    dcall(print("propState", propState));
+    dcall(print("updatedState", updatedState));
     if (!propState.valid || !updatedState.valid) {
       dprint("Failed propagation " << "hitR, propR, updR = " << hit.r() << ", " << Mag(propPos) << ", " << Mag(updPos));
 #ifdef CHECKSTATEVALID

--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -1,4 +1,5 @@
 #include "CandCloner.h"
+//#define DEBUG
 #include "Debug.h"
 
 namespace

--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -1,4 +1,5 @@
 #include "CandCloner.h"
+#include "Debug.h"
 
 namespace
 {
@@ -30,15 +31,14 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
 #ifdef DEBUG
     int th_start_seed = m_start_seed;
 
-    std::cout << "dump seed n " << is << " with input candidates=" << hitsForSeed.size() << std::endl;
+    dprint("dump seed n " << is << " with input candidates=" << hitsForSeed.size());
     for (int ih = 0; ih<hitsForSeed.size(); ih++)
     {
-      std::cout << "trkIdx=" << hitsForSeed[ih].trkIdx << " hitIdx=" << hitsForSeed[ih].hitIdx << " chi2=" <<  hitsForSeed[ih].chi2 << std::endl;
-      std::cout << "original pt=" << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].pT() << " " 
-                << "nTotalHits="  << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].nTotalHits() << " " 
-                << "nFoundHits="  << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].nFoundHits() << " " 
-                << "chi2="        << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].chi2() << " " 
-                << std::endl;
+      dprint("trkIdx=" << hitsForSeed[ih].trkIdx << " hitIdx=" << hitsForSeed[ih].hitIdx << " chi2=" <<  hitsForSeed[ih].chi2 << std::endl
+                << "original pt=" << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].pT() << " "
+                << "nTotalHits="  << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].nTotalHits() << " "
+                << "nFoundHits="  << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].nFoundHits() << " "
+                << "chi2="        << cands[th_start_seed+is][hitsForSeed[ih].trkIdx].chi2());
     }
 #endif
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -4,6 +4,7 @@
 #include "Config.h"
 #include "Hit.h"
 #include "Track.h"
+#include "Debug.h"
 
 // for each layer
 //   Config::nEtaBin vectors of hits, resized to large enough N
@@ -321,7 +322,7 @@ public:
       m_etabins_of_comb_candidates[bin].InsertSeed(seed);
     } 
 #ifdef DEBUG
-    else std::cout << "excluding seed with r=" << seed.posR() << " etaBin=" << bin << std::endl;
+    else { dprint("excluding seed with r=" << seed.posR() << " etaBin=" << bin) };
 #endif
   }
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -322,7 +322,7 @@ public:
       m_etabins_of_comb_candidates[bin].InsertSeed(seed);
     } 
 #ifdef DEBUG
-    else { dprint("excluding seed with r=" << seed.posR() << " etaBin=" << bin) };
+    else { dprint("excluding seed with r=" << seed.posR() << " etaBin=" << bin); };
 #endif
   }
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -4,6 +4,7 @@
 #include "Config.h"
 #include "Hit.h"
 #include "Track.h"
+//#define DEBUG
 #include "Debug.h"
 
 // for each layer

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -1,5 +1,6 @@
 #include "KalmanUtilsMPlex.h"
 #include "PropagationMPlex.h"
+//#define DEBUG
 #include "Debug.h"
 
 namespace

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -1,5 +1,6 @@
 #include "KalmanUtilsMPlex.h"
 #include "PropagationMPlex.h"
+#include "Debug.h"
 
 namespace
 {
@@ -596,7 +597,7 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   // Can be passed in in a struct, see above.
 
 #ifdef DEBUG
-  const bool dump = g_dump;
+  const bool debug = g_dump;
 #endif
 
   // updateParametersContext ctx;
@@ -613,7 +614,8 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   }
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("propPar:\n");
     for (int i = 0; i < 6; ++i) { 
       printf("%8f ", propPar.ConstAt(0,0,i)); printf("\n");
@@ -665,7 +667,8 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   ProjectResErrTransp(rotT00, rotT01, tempHH, resErr_loc);
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("resErr:\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");
@@ -706,7 +709,8 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
   CartesianErrTransp(jac_pol, tempLL, outErr);// outErr is in cartesian coordinates now
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("res_glo:\n");
     for (int i = 0; i < 3; ++i) {
         printf("%8f ", res_glo.At(0,i,0));
@@ -752,7 +756,7 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
   // Can be passed in in a struct, see above.
 
 #ifdef DEBUG
-  const bool dump = g_dump;
+  const bool debug = g_dump;
 #endif
 
   // updateParametersContext ctx;
@@ -769,7 +773,8 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
   }
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("propPar:\n");
     for (int i = 0; i < 6; ++i) { 
       printf("%8f ", propPar.ConstAt(0,0,i)); printf("\n");
@@ -820,7 +825,8 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
   ProjectResErrTransp(rotT00, rotT01, tempHH, resErr_loc);
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("resErr_loc:\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");
@@ -832,7 +838,8 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
   Matriplex::InvertCramerSym(resErr_loc);
 
 #ifdef DEBUG
-  if (dump) {
+  if (debug) {
+    dmutex;
     printf("resErr_loc (Inv):\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -615,7 +615,7 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("propPar:\n");
     for (int i = 0; i < 6; ++i) { 
       printf("%8f ", propPar.ConstAt(0,0,i)); printf("\n");
@@ -668,7 +668,7 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("resErr:\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");
@@ -710,7 +710,7 @@ void updateParametersMPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MP
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("res_glo:\n");
     for (int i = 0; i < 3; ++i) {
         printf("%8f ", res_glo.At(0,i,0));
@@ -774,7 +774,7 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("propPar:\n");
     for (int i = 0; i < 6; ++i) { 
       printf("%8f ", propPar.ConstAt(0,0,i)); printf("\n");
@@ -826,7 +826,7 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("resErr_loc:\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");
@@ -839,7 +839,7 @@ void computeChi2MPlex(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI
 
 #ifdef DEBUG
   if (debug) {
-    dmutex;
+    dmutex_guard;
     printf("resErr_loc (Inv):\n");
     for (int i = 0; i < 2; ++i) { for (int j = 0; j < 2; ++j)
         printf("%8f ", resErr_loc.At(0,i,j)); printf("\n");

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -63,8 +63,6 @@ namespace {
       }
     }
   }
-
-  bool debug = true;
 }
 #endif
 

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -710,8 +710,10 @@ void MkFitter::SelectHitRanges(BunchOfHits &bunch_of_hits, const int N_proc)
 
 #ifdef DEBUG
     xout << "found range firstHit=" << XHitPos.At(itrack, 0, 0) << " size=" << XHitSize.At(itrack, 0, 0) << std::endl;
-    if (xout_dump)
-       std::cout << xout.str();
+    if (xout_dump) {
+      dmutex;
+      std::cout << xout.str();
+    }
 #endif
 
   }

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -711,7 +711,7 @@ void MkFitter::SelectHitRanges(BunchOfHits &bunch_of_hits, const int N_proc)
 #ifdef DEBUG
     xout << "found range firstHit=" << XHitPos.At(itrack, 0, 0) << " size=" << XHitSize.At(itrack, 0, 0) << std::endl;
     if (xout_dump) {
-      dmutex;
+      dmutex_guard;
       std::cout << xout.str();
     }
 #endif

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -7,6 +7,9 @@
 #include "FitterCU.h"
 #endif
 
+//#define DEBUG
+#include "Debug.h"
+
 #include <sstream>
 
 void MkFitter::CheckAlignment()
@@ -294,10 +297,8 @@ void MkFitter::AddBestHit(std::vector<Hit>& lay_hits, int firstHit, int lastHit,
   for (int layhit = firstHit; layhit<lastHit; ++ih, ++layhit) {
 
     Hit &hit = lay_hits[layhit];
-#ifdef DEBUG
-    std::cout << "consider hit #" << ih << " of " << lay_hits.size() << std::endl;
-    std::cout << "hit x=" << hit.position()[0] << " y=" << hit.position()[1] << std::endl;      
-#endif
+    dprint("consider hit #" << ih << " of " << lay_hits.size() << std::endl
+          << "hit x=" << hit.position()[0] << " y=" << hit.position()[1]);
 
     //create a dummy matriplex with N times the same hit
     //fixme this is just because I'm lazy and do not want to rewrite the chi2 calculation for simple vectors mixed with matriplex
@@ -323,9 +324,7 @@ void MkFitter::AddBestHit(std::vector<Hit>& lay_hits, int firstHit, int lastHit,
     for (int i = beg; i < end; ++i, ++itrack)
     {
       float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-      std::cout << "chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack] << std::endl;      
-#endif
+      dprint("chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack]);
       if (chi2<minChi2[itrack]) 
       {
 	minChi2[itrack]=chi2;
@@ -347,11 +346,9 @@ void MkFitter::AddBestHit(std::vector<Hit>& lay_hits, int firstHit, int lastHit,
       Hit   &hit  = lay_hits[ bestHit[itrack] ];
       float &chi2 = minChi2[itrack];
 
-#ifdef DEBUG
-      std::cout << "ADD BEST HIT FOR TRACK #" << i << std::endl;
-      std::cout << "prop x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl;      
-      std::cout << "copy in hit #" << bestHit[itrack] << " x=" << hit.position()[0] << " y=" << hit.position()[1] << std::endl;    
-#endif
+      dprint("ADD BEST HIT FOR TRACK #" << i << std::endl
+        << "prop x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl
+        << "copy in hit #" << bestHit[itrack] << " x=" << hit.position()[0] << " y=" << hit.position()[1]);
 
       msErr[Nhits].CopyIn(itrack, hit.errArray());
       msPar[Nhits].CopyIn(itrack, hit.posArray());
@@ -360,9 +357,7 @@ void MkFitter::AddBestHit(std::vector<Hit>& lay_hits, int firstHit, int lastHit,
     }
     else
     {
-#ifdef DEBUG
-      std::cout << "ADD FAKE HIT FOR TRACK #" << i << std::endl;
-#endif
+      dprint("ADD FAKE HIT FOR TRACK #" << i);
 
       msErr[Nhits].SetDiagonal3x3(itrack, 666);
       msPar[Nhits](itrack,0,0) = Par[iP](itrack,0,0);
@@ -375,9 +370,7 @@ void MkFitter::AddBestHit(std::vector<Hit>& lay_hits, int firstHit, int lastHit,
   }
 
   //now update the track parameters with this hit (note that some calculations are already done when computing chi2... not sure it's worth caching them?)
-#ifdef DEBUG
-  std::cout << "update parameters" << std::endl;
-#endif
+  dprint("update parameters");
   updateParametersMPlex(Err[iP], Par[iP], Chg, msErr[Nhits], msPar[Nhits],
 			Err[iC], Par[iC]);
 
@@ -392,10 +385,8 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
   {
 
     Hit &hit = lay_hits[ih];
-#ifdef DEBUG
-    std::cout << "consider hit #" << ih << " of " << lay_hits.size() << std::endl;
-    std::cout << "hit x=" << hit.position()[0] << " y=" << hit.position()[1] << std::endl;      
-#endif
+    dprint("consider hit #" << ih << " of " << lay_hits.size() << std::endl
+      << "hit x=" << hit.position()[0] << " y=" << hit.position()[1]);
 
     //create a dummy matriplex with N times the same hit
     //fixme this is just because I'm lazy and do not want to rewrite the chi2 calculation for simple vectors mixed with matriplex
@@ -421,9 +412,7 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
     for (int i = beg; i < end; ++i, ++itrack)
       {
 	float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-	std::cout << "chi2=" << chi2 << std::endl;
-#endif
+	dprint("chi2=" << chi2);
 	if (chi2<Config::chi2Cut)
 	  {
 	    oneCandPassCut = true;
@@ -435,12 +424,10 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
 
       updateParametersMPlex(Err[iP], Par[iP], Chg, msErr_oneHit, msPar_oneHit,
 			    Err[iC], Par[iC]);
-#ifdef DEBUG
-      std::cout << "update parameters" << std::endl;
-      std::cout << "propagated track parameters x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl;
-      std::cout << "               hit position x=" << msPar_oneHit.ConstAt(itrack, 0, 0) << " y=" << msPar_oneHit.ConstAt(itrack, 1, 0) << std::endl;
-      std::cout << "   updated track parameters x=" << Par[iC].ConstAt(itrack, 0, 0) << " y=" << Par[iC].ConstAt(itrack, 1, 0) << std::endl;
-#endif
+      dprint("update parameters" << std::endl
+        << "propagated track parameters x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl
+        << "               hit position x=" << msPar_oneHit.ConstAt(itrack, 0, 0) << " y=" << msPar_oneHit.ConstAt(itrack, 1, 0) << std::endl
+        << "   updated track parameters x=" << Par[iC].ConstAt(itrack, 0, 0) << " y=" << Par[iC].ConstAt(itrack, 1, 0));
 
       //create candidate with hit in case chi2<Config::chi2Cut
       itrack = 0;
@@ -448,14 +435,10 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
       for (int i = beg; i < end; ++i, ++itrack)
 	{
 	  float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-	  std::cout << "chi2=" << chi2 << std::endl;      
-#endif
+	  dprint("chi2=" << chi2);
 	  if (chi2<Config::chi2Cut)
 	    {
-#ifdef DEBUG
-	      std::cout << "chi2 cut passed, creating new candidate" << std::endl;
-#endif
+	      dprint("chi2 cut passed, creating new candidate");
 	      //create a new candidate and fill the reccands_tmp vector
 	      Track newcand;
 	      newcand.resetHits();//probably not needed
@@ -465,18 +448,14 @@ void MkFitter::FindCandidates(std::vector<Hit>& lay_hits, int firstHit, int last
 		{
 		  newcand.addHitIdx(HitsIdx[hi](itrack, 0, 0),0.);//this should be ok since we already set the chi2 above
 		}
-#ifdef DEBUG
-	      std::cout << "output new hit with x=" << hit.position()[0] << std::endl;
-#endif
+	      dprint("output new hit with x=" << hit.position()[0]);
 
 	      newcand.addHitIdx(ih,chi2);
 	      //set the track state to the updated parameters
 	      Err[iC].CopyOut(itrack, newcand.errors_nc().Array());
 	      Par[iC].CopyOut(itrack, newcand.parameters_nc().Array());
 	      
-#ifdef DEBUG
-	      std::cout << "updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << std::endl;
-#endif
+	      dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1]);
 	      
 	      tmp_candidates[SeedIdx(itrack, 0, 0)-offset].push_back(newcand);
 	    }
@@ -568,16 +547,12 @@ void MkFitter::GetHitRange(std::vector<std::vector<BinInfo> >& segmentMapLay_, i
 
 	//fixme: if more than one eta bin we are looping over a huge range (need to make sure we are in the same eta bin)
 
-#ifdef DEBUG
-	std::cout << "propagated track parameters eta=" << eta << " bin=" << etabin << " begin=" << binInfoMinus.first << " end=" << binInfoPlus.first+binInfoPlus.second << std::endl;
-#endif
+	dprint("propagated track parameters eta=" << eta << " bin=" << etabin << " begin=" << binInfoMinus.first << " end=" << binInfoPlus.first+binInfoPlus.second);
 	if (firstHit==-1 || binInfoMinus.first<firstHit) firstHit =  binInfoMinus.first;
 	if (lastHit==-1 || (binInfoPlus.first+binInfoPlus.second)>lastHit) lastHit = binInfoPlus.first+binInfoPlus.second;
       }
-#ifdef DEBUG
-    std::cout << "found range firstHit=" << firstHit << " lastHit=" << lastHit << std::endl;
-#endif
-}
+    dprint("found range firstHit=" << firstHit << " lastHit=" << lastHit);
+  }
 
 
 // ======================================================================================
@@ -867,9 +842,7 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
       // make sure the hit was in the compatiblity window for the candidate
       if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
       float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-      std::cout << "chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack] << std::endl;      
-#endif
+      dprint("chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack]);
       if (chi2 < minChi2[itrack]) 
       {
         minChi2[itrack]=chi2;
@@ -894,11 +867,9 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
       Hit   &hit  = bunch_of_hits.m_hits[ XHitPos.At(itrack, 0, 0) + bestHit[itrack] ];
       float &chi2 = minChi2[itrack];
 
-#ifdef DEBUG
-      std::cout << "ADD BEST HIT FOR TRACK #" << itrack << std::endl;
-      std::cout << "prop x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl;      
-      std::cout << "copy in hit #" << bestHit[itrack] << " x=" << hit.position()[0] << " y=" << hit.position()[1] << std::endl;    
-#endif
+      dprint("ADD BEST HIT FOR TRACK #" << itrack << std::endl
+        << "prop x=" << Par[iP].ConstAt(itrack, 0, 0) << " y=" << Par[iP].ConstAt(itrack, 1, 0) << std::endl
+        << "copy in hit #" << bestHit[itrack] << " x=" << hit.position()[0] << " y=" << hit.position()[1]);
 	  
       msErr[Nhits].CopyIn(itrack, hit.errArray());
       msPar[Nhits].CopyIn(itrack, hit.posArray());
@@ -907,9 +878,7 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
     }
     else
     {
-#ifdef DEBUG
-      std::cout << "ADD FAKE HIT FOR TRACK #" << itrack << std::endl;
-#endif
+      dprint("ADD FAKE HIT FOR TRACK #" << itrack);
 
       msErr[Nhits].SetDiagonal3x3(itrack, 666);
       msPar[Nhits](itrack,0,0) = Par[iP](itrack,0,0);
@@ -922,9 +891,7 @@ void MkFitter::AddBestHit(BunchOfHits &bunch_of_hits)
   }
 
   //now update the track parameters with this hit (note that some calculations are already done when computing chi2... not sure it's worth caching them?)
-#ifdef DEBUG
-  std::cout << "update parameters" << std::endl;
-#endif
+  dprint("update parameters");
   updateParametersMPlex(Err[iP], Par[iP], Chg, msErr[Nhits], msPar[Nhits],
 			Err[iC], Par[iC]);
 
@@ -1039,9 +1006,7 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
 	// make sure the hit was in the compatiblity window for the candidate
 	if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
 	float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-	std::cout << "chi2=" << chi2 << std::endl;
-#endif
+	dprint("chi2=" << chi2);
 	if (chi2 < Config::chi2Cut)
 	  {
 	    oneCandPassCut = true;
@@ -1052,12 +1017,10 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
     if (oneCandPassCut)
     {
       updateParametersMPlex(Err[iP], Par[iP], Chg, msErr[Nhits], msPar[Nhits], Err[iC], Par[iC]);
-#ifdef DEBUG
-      std::cout << "update parameters" << std::endl;
-      std::cout << "propagated track parameters x=" << Par[iP].ConstAt(0, 0, 0) << " y=" << Par[iP].ConstAt(0, 1, 0) << std::endl;
-      std::cout << "               hit position x=" << msPar[Nhits].ConstAt(0, 0, 0) << " y=" << msPar[Nhits].ConstAt(0, 1, 0) << std::endl;
-      std::cout << "   updated track parameters x=" << Par[iC].ConstAt(0, 0, 0) << " y=" << Par[iC].ConstAt(0, 1, 0) << std::endl;
-#endif
+      dprint("update parameters" << std::endl
+        << "propagated track parameters x=" << Par[iP].ConstAt(0, 0, 0) << " y=" << Par[iP].ConstAt(0, 1, 0) << std::endl
+        << "               hit position x=" << msPar[Nhits].ConstAt(0, 0, 0) << " y=" << msPar[Nhits].ConstAt(0, 1, 0) << std::endl
+        << "   updated track parameters x=" << Par[iC].ConstAt(0, 0, 0) << " y=" << Par[iC].ConstAt(0, 1, 0));
 
       //create candidate with hit in case chi2<Config::chi2Cut
       //fixme: please vectorize me... (not sure it's possible in this case)
@@ -1066,14 +1029,10 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
 	  // make sure the hit was in the compatiblity window for the candidate
 	  if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
 	  float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-	  std::cout << "chi2=" << chi2 << std::endl;      
-#endif
+	  dprint("chi2=" << chi2);
 	  if (chi2<Config::chi2Cut)
 	    {
-#ifdef DEBUG
-	      std::cout << "chi2 cut passed, creating new candidate" << std::endl;
-#endif
+	      dprint("chi2 cut passed, creating new candidate");
 	      //create a new candidate and fill the reccands_tmp vector
 	      Track newcand;
 	      newcand.resetHits();//probably not needed
@@ -1089,9 +1048,7 @@ void MkFitter::FindCandidates(BunchOfHits &bunch_of_hits,
 	      Err[iC].CopyOut(itrack, newcand.errors_nc().Array());
 	      Par[iC].CopyOut(itrack, newcand.parameters_nc().Array());
 
-#ifdef DEBUG
-	      std::cout << "updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << std::endl;
-#endif
+	      dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1]);
 
 	      tmp_candidates[SeedIdx(itrack, 0, 0)-offset].push_back(newcand);
 	    }
@@ -1236,9 +1193,7 @@ void MkFitter::FindCandidatesMinimizeCopy(BunchOfHits &bunch_of_hits, CandCloner
 	if (hit_cnt >= XHitSize.At(itrack, 0, 0)) continue;
 
 	float chi2 = fabs(outChi2[itrack]);//fixme negative chi2 sometimes...
-#ifdef DEBUG
-	std::cout << "chi2=" << chi2 << " for trkIdx=" << itrack << std::endl;
-#endif
+	dprint("chi2=" << chi2 << " for trkIdx=" << itrack);
 	if (chi2 < Config::chi2Cut) 
 	  {
 	    IdxChi2List tmpList;
@@ -1248,9 +1203,7 @@ void MkFitter::FindCandidatesMinimizeCopy(BunchOfHits &bunch_of_hits, CandCloner
 	    tmpList.chi2   = Chi2(itrack, 0, 0) + chi2;
             cloner.add_cand(SeedIdx(itrack, 0, 0) - offset, tmpList);
 	    // hitsToAdd[SeedIdx(itrack, 0, 0)-offset].push_back(tmpList);
-#ifdef DEBUG
-	    std::cout << "adding hit with hit_cnt=" << hit_cnt << " for trkIdx=" << tmpList.trkIdx << " orig Seed=" << Label(itrack, 0, 0) << std::endl;
-#endif
+	    dprint("adding hit with hit_cnt=" << hit_cnt << " for trkIdx=" << tmpList.trkIdx << " orig Seed=" << Label(itrack, 0, 0));
 	  }
       }
     
@@ -1260,9 +1213,7 @@ void MkFitter::FindCandidatesMinimizeCopy(BunchOfHits &bunch_of_hits, CandCloner
   //fixme: please vectorize me...
   for (int itrack = 0; itrack < N_proc; ++itrack)
     {
-#ifdef DEBUG
-      std::cout << "countInvalidHits(" << itrack << ")=" << countInvalidHits(itrack) << std::endl;
-#endif
+      dprint("countInvalidHits(" << itrack << ")=" << countInvalidHits(itrack));
 
       int hit_idx = countInvalidHits(itrack) < Config::maxHolesPerCand ? -1 : -2;
 
@@ -1273,9 +1224,7 @@ void MkFitter::FindCandidatesMinimizeCopy(BunchOfHits &bunch_of_hits, CandCloner
       tmpList.chi2   = Chi2(itrack, 0, 0);
       cloner.add_cand(SeedIdx(itrack, 0, 0) - offset, tmpList);
       // hitsToAdd[SeedIdx(itrack, 0, 0)-offset].push_back(tmpList);
-#ifdef DEBUG
-      std::cout << "adding invalid hit" << std::endl;
-#endif
+      dprint("adding invalid hit");
     }
 }
 
@@ -1364,9 +1313,7 @@ void MkFitter::UpdateWithHit(BunchOfHits &bunch_of_hits,
 	Err[iC].CopyOut(itrack, newcand.errors_nc().Array());
 	Par[iC].CopyOut(itrack, newcand.parameters_nc().Array());
       }
-#ifdef DEBUG
-      std::cout << "updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << std::endl;
-#endif
+      dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1]);
 
       cands_for_next_lay[SeedIdx(itrack, 0, 0) - offset].push_back(newcand);
     }
@@ -1470,9 +1417,7 @@ void MkFitter::CopyOutClone(std::vector<std::pair<int,IdxChi2List> >& idxs,
       Err[iO].CopyOut(itrack, newcand.errors_nc().Array());
       Par[iO].CopyOut(itrack, newcand.parameters_nc().Array());
 
-#ifdef DEBUG
-      std::cout << "updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << std::endl;
-#endif
+      dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1]);
 
       cands_for_next_lay[SeedIdx(itrack, 0, 0) - offset].push_back(newcand);
     }
@@ -1492,12 +1437,10 @@ void MkFitter::CopyOutParErr(std::vector<std::vector<Track> >& seed_cand_vec,
     Err[iO].CopyOut(i, cand.errors_nc().Array());
     Par[iO].CopyOut(i, cand.parameters_nc().Array());
 
-#ifdef DEBUG
-    std::cout << "updated track parameters x=" << cand.parameters()[0]
+    dprint("updated track parameters x=" << cand.parameters()[0]
               << " y=" << cand.parameters()[1]
               << " z=" << cand.parameters()[2]
               << " posEta=" << cand.posEta()
-              << " etaBin=" << getEtaBin(cand.posEta()) << std::endl;
-#endif
+              << " etaBin=" << getEtaBin(cand.posEta()));
   }
 }

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -457,7 +457,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	
 #ifdef DEBUG
         {
-          dmutex;
+          dmutex_guard;
         	std::cout << "rotateCartCu2Ca" << std::endl;
         	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,0,0),rotateCartCu2Ca(n,0,1),rotateCartCu2Ca(n,0,2),rotateCartCu2Ca(n,0,3),rotateCartCu2Ca(n,0,4),rotateCartCu2Ca(n,0,5));
         	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,1,0),rotateCartCu2Ca(n,1,1),rotateCartCu2Ca(n,1,2),rotateCartCu2Ca(n,1,3),rotateCartCu2Ca(n,1,4),rotateCartCu2Ca(n,1,5));
@@ -489,7 +489,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 
 #ifdef DEBUG
         {
-          dmutex;
+          dmutex_guard;
         	std::cout << "jacCartToCurv" << std::endl;
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,0,0),jacCartToCurv(n,0,1),jacCartToCurv(n,0,2),jacCartToCurv(n,0,3),jacCartToCurv(n,0,4),jacCartToCurv(n,0,5));
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,1,0),jacCartToCurv(n,1,1),jacCartToCurv(n,1,2),jacCartToCurv(n,1,3),jacCartToCurv(n,1,4),jacCartToCurv(n,1,5));
@@ -521,7 +521,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 
 #ifdef DEBUG
         {
-          dmutex;
+          dmutex_guard;
         	std::cout << "jacCurvToCart" << std::endl;
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,0,0),jacCurvToCart(n,0,1),jacCurvToCart(n,0,2),jacCurvToCart(n,0,3),jacCurvToCart(n,0,4),jacCurvToCart(n,0,5));
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,1,0),jacCurvToCart(n,1,1),jacCurvToCart(n,1,2),jacCurvToCart(n,1,3),jacCurvToCart(n,1,4),jacCurvToCart(n,1,5));
@@ -675,7 +675,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 
 #ifdef DEBUG
         {
-          dmutex;
+          dmutex_guard;
         	std::cout << "jacCurvProp" << std::endl;
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,0,0),jacCurvProp(n,0,1),jacCurvProp(n,0,2),jacCurvProp(n,0,3),jacCurvProp(n,0,4),jacCurvProp(n,0,5));
         	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,1,0),jacCurvProp(n,1,1),jacCurvProp(n,1,2),jacCurvProp(n,1,3),jacCurvProp(n,1,4),jacCurvProp(n,1,5));
@@ -690,7 +690,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	MultHelixPropFull(jacCartToCurv, rotateCartCa2Cu, temp5);
 #ifdef DEBUG
   {
-    dmutex;
+    dmutex_guard;
   	std::cout << "rotated jacCartToCurv" << std::endl;
   	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,0,0),temp5(n,0,1),temp5(n,0,2),temp5(n,0,3),temp5(n,0,4),temp5(n,0,5));
   	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,1,0),temp5(n,1,1),temp5(n,1,2),temp5(n,1,3),temp5(n,1,4),temp5(n,1,5));
@@ -704,7 +704,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	MultHelixPropFull(rotateCartCu2Ca, jacCurvToCart, temp6);
 #ifdef DEBUG
   {
-    dmutex;
+    dmutex_guard;
   	std::cout << "rotated jacCurvToCart" << std::endl;
   	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,0,0),temp6(n,0,1),temp6(n,0,2),temp6(n,0,3),temp6(n,0,4),temp6(n,0,5));
   	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,1,0),temp6(n,1,1),temp6(n,1,2),temp6(n,1,3),temp6(n,1,4),temp6(n,1,5));
@@ -719,7 +719,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	MultHelixPropFull(temp6, temp7, errorProp);
 #ifdef DEBUG
   {
-    dmutex;
+    dmutex_guard;
   	std::cout << "jacobian iterative" << std::endl;
   	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
   	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
@@ -792,7 +792,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 
 #ifdef DEBUG
       {
-        dmutex;
+        dmutex_guard;
         std::cout << "jacobian iterative" << std::endl;
         printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
         printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
@@ -957,7 +957,7 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
 
 #ifdef DEBUG
       {
-        dmutex;
+        dmutex_guard;
         std::cout << "jacobian intersection" << std::endl;
         printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
         printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -456,20 +456,23 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         rotateCartCa2Cu(n,5,5) = 1.0;
 	
 #ifdef DEBUG
-	std::cout << "rotateCartCu2Ca" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,0,0),rotateCartCu2Ca(n,0,1),rotateCartCu2Ca(n,0,2),rotateCartCu2Ca(n,0,3),rotateCartCu2Ca(n,0,4),rotateCartCu2Ca(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,1,0),rotateCartCu2Ca(n,1,1),rotateCartCu2Ca(n,1,2),rotateCartCu2Ca(n,1,3),rotateCartCu2Ca(n,1,4),rotateCartCu2Ca(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,2,0),rotateCartCu2Ca(n,2,1),rotateCartCu2Ca(n,2,2),rotateCartCu2Ca(n,2,3),rotateCartCu2Ca(n,2,4),rotateCartCu2Ca(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,3,0),rotateCartCu2Ca(n,3,1),rotateCartCu2Ca(n,3,2),rotateCartCu2Ca(n,3,3),rotateCartCu2Ca(n,3,4),rotateCartCu2Ca(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,4,0),rotateCartCu2Ca(n,4,1),rotateCartCu2Ca(n,4,2),rotateCartCu2Ca(n,4,3),rotateCartCu2Ca(n,4,4),rotateCartCu2Ca(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,5,0),rotateCartCu2Ca(n,5,1),rotateCartCu2Ca(n,5,2),rotateCartCu2Ca(n,5,3),rotateCartCu2Ca(n,5,4),rotateCartCu2Ca(n,5,5));
-	std::cout << "rotateCartCa2Cu" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,0,0),rotateCartCa2Cu(n,0,1),rotateCartCa2Cu(n,0,2),rotateCartCa2Cu(n,0,3),rotateCartCa2Cu(n,0,4),rotateCartCa2Cu(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,1,0),rotateCartCa2Cu(n,1,1),rotateCartCa2Cu(n,1,2),rotateCartCa2Cu(n,1,3),rotateCartCa2Cu(n,1,4),rotateCartCa2Cu(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,2,0),rotateCartCa2Cu(n,2,1),rotateCartCa2Cu(n,2,2),rotateCartCa2Cu(n,2,3),rotateCartCa2Cu(n,2,4),rotateCartCa2Cu(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,3,0),rotateCartCa2Cu(n,3,1),rotateCartCa2Cu(n,3,2),rotateCartCa2Cu(n,3,3),rotateCartCa2Cu(n,3,4),rotateCartCa2Cu(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,4,0),rotateCartCa2Cu(n,4,1),rotateCartCa2Cu(n,4,2),rotateCartCa2Cu(n,4,3),rotateCartCa2Cu(n,4,4),rotateCartCa2Cu(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,5,0),rotateCartCa2Cu(n,5,1),rotateCartCa2Cu(n,5,2),rotateCartCa2Cu(n,5,3),rotateCartCa2Cu(n,5,4),rotateCartCa2Cu(n,5,5));
+        {
+          dmutex;
+        	std::cout << "rotateCartCu2Ca" << std::endl;
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,0,0),rotateCartCu2Ca(n,0,1),rotateCartCu2Ca(n,0,2),rotateCartCu2Ca(n,0,3),rotateCartCu2Ca(n,0,4),rotateCartCu2Ca(n,0,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,1,0),rotateCartCu2Ca(n,1,1),rotateCartCu2Ca(n,1,2),rotateCartCu2Ca(n,1,3),rotateCartCu2Ca(n,1,4),rotateCartCu2Ca(n,1,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,2,0),rotateCartCu2Ca(n,2,1),rotateCartCu2Ca(n,2,2),rotateCartCu2Ca(n,2,3),rotateCartCu2Ca(n,2,4),rotateCartCu2Ca(n,2,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,3,0),rotateCartCu2Ca(n,3,1),rotateCartCu2Ca(n,3,2),rotateCartCu2Ca(n,3,3),rotateCartCu2Ca(n,3,4),rotateCartCu2Ca(n,3,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,4,0),rotateCartCu2Ca(n,4,1),rotateCartCu2Ca(n,4,2),rotateCartCu2Ca(n,4,3),rotateCartCu2Ca(n,4,4),rotateCartCu2Ca(n,4,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCu2Ca(n,5,0),rotateCartCu2Ca(n,5,1),rotateCartCu2Ca(n,5,2),rotateCartCu2Ca(n,5,3),rotateCartCu2Ca(n,5,4),rotateCartCu2Ca(n,5,5));
+        	std::cout << "rotateCartCa2Cu" << std::endl;
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,0,0),rotateCartCa2Cu(n,0,1),rotateCartCa2Cu(n,0,2),rotateCartCa2Cu(n,0,3),rotateCartCa2Cu(n,0,4),rotateCartCa2Cu(n,0,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,1,0),rotateCartCa2Cu(n,1,1),rotateCartCa2Cu(n,1,2),rotateCartCa2Cu(n,1,3),rotateCartCa2Cu(n,1,4),rotateCartCa2Cu(n,1,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,2,0),rotateCartCa2Cu(n,2,1),rotateCartCa2Cu(n,2,2),rotateCartCa2Cu(n,2,3),rotateCartCa2Cu(n,2,4),rotateCartCa2Cu(n,2,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,3,0),rotateCartCa2Cu(n,3,1),rotateCartCa2Cu(n,3,2),rotateCartCa2Cu(n,3,3),rotateCartCa2Cu(n,3,4),rotateCartCa2Cu(n,3,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,4,0),rotateCartCa2Cu(n,4,1),rotateCartCa2Cu(n,4,2),rotateCartCa2Cu(n,4,3),rotateCartCa2Cu(n,4,4),rotateCartCa2Cu(n,4,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", rotateCartCa2Cu(n,5,0),rotateCartCa2Cu(n,5,1),rotateCartCa2Cu(n,5,2),rotateCartCa2Cu(n,5,3),rotateCartCa2Cu(n,5,4),rotateCartCa2Cu(n,5,5));
+        }
 #endif
 	
         jacCartToCurv(n,0,3) = -q*pxin/p3;        
@@ -485,13 +488,16 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         jacCartToCurv(n,4,2) = 1.;
 
 #ifdef DEBUG
-	std::cout << "jacCartToCurv" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,0,0),jacCartToCurv(n,0,1),jacCartToCurv(n,0,2),jacCartToCurv(n,0,3),jacCartToCurv(n,0,4),jacCartToCurv(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,1,0),jacCartToCurv(n,1,1),jacCartToCurv(n,1,2),jacCartToCurv(n,1,3),jacCartToCurv(n,1,4),jacCartToCurv(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,2,0),jacCartToCurv(n,2,1),jacCartToCurv(n,2,2),jacCartToCurv(n,2,3),jacCartToCurv(n,2,4),jacCartToCurv(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,3,0),jacCartToCurv(n,3,1),jacCartToCurv(n,3,2),jacCartToCurv(n,3,3),jacCartToCurv(n,3,4),jacCartToCurv(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,4,0),jacCartToCurv(n,4,1),jacCartToCurv(n,4,2),jacCartToCurv(n,4,3),jacCartToCurv(n,4,4),jacCartToCurv(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,5,0),jacCartToCurv(n,5,1),jacCartToCurv(n,5,2),jacCartToCurv(n,5,3),jacCartToCurv(n,5,4),jacCartToCurv(n,5,5));
+        {
+          dmutex;
+        	std::cout << "jacCartToCurv" << std::endl;
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,0,0),jacCartToCurv(n,0,1),jacCartToCurv(n,0,2),jacCartToCurv(n,0,3),jacCartToCurv(n,0,4),jacCartToCurv(n,0,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,1,0),jacCartToCurv(n,1,1),jacCartToCurv(n,1,2),jacCartToCurv(n,1,3),jacCartToCurv(n,1,4),jacCartToCurv(n,1,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,2,0),jacCartToCurv(n,2,1),jacCartToCurv(n,2,2),jacCartToCurv(n,2,3),jacCartToCurv(n,2,4),jacCartToCurv(n,2,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,3,0),jacCartToCurv(n,3,1),jacCartToCurv(n,3,2),jacCartToCurv(n,3,3),jacCartToCurv(n,3,4),jacCartToCurv(n,3,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,4,0),jacCartToCurv(n,4,1),jacCartToCurv(n,4,2),jacCartToCurv(n,4,3),jacCartToCurv(n,4,4),jacCartToCurv(n,4,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCartToCurv(n,5,0),jacCartToCurv(n,5,1),jacCartToCurv(n,5,2),jacCartToCurv(n,5,3),jacCartToCurv(n,5,4),jacCartToCurv(n,5,5));
+        }
 #endif
 	
         float sinlambda = pz/p;//fixme check sign
@@ -514,13 +520,16 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         jacCurvToCart(n,5,2) = 0.;
 
 #ifdef DEBUG
-	std::cout << "jacCurvToCart" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,0,0),jacCurvToCart(n,0,1),jacCurvToCart(n,0,2),jacCurvToCart(n,0,3),jacCurvToCart(n,0,4),jacCurvToCart(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,1,0),jacCurvToCart(n,1,1),jacCurvToCart(n,1,2),jacCurvToCart(n,1,3),jacCurvToCart(n,1,4),jacCurvToCart(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,2,0),jacCurvToCart(n,2,1),jacCurvToCart(n,2,2),jacCurvToCart(n,2,3),jacCurvToCart(n,2,4),jacCurvToCart(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,3,0),jacCurvToCart(n,3,1),jacCurvToCart(n,3,2),jacCurvToCart(n,3,3),jacCurvToCart(n,3,4),jacCurvToCart(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,4,0),jacCurvToCart(n,4,1),jacCurvToCart(n,4,2),jacCurvToCart(n,4,3),jacCurvToCart(n,4,4),jacCurvToCart(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,5,0),jacCurvToCart(n,5,1),jacCurvToCart(n,5,2),jacCurvToCart(n,5,3),jacCurvToCart(n,5,4),jacCurvToCart(n,5,5));
+        {
+          dmutex;
+        	std::cout << "jacCurvToCart" << std::endl;
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,0,0),jacCurvToCart(n,0,1),jacCurvToCart(n,0,2),jacCurvToCart(n,0,3),jacCurvToCart(n,0,4),jacCurvToCart(n,0,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,1,0),jacCurvToCart(n,1,1),jacCurvToCart(n,1,2),jacCurvToCart(n,1,3),jacCurvToCart(n,1,4),jacCurvToCart(n,1,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,2,0),jacCurvToCart(n,2,1),jacCurvToCart(n,2,2),jacCurvToCart(n,2,3),jacCurvToCart(n,2,4),jacCurvToCart(n,2,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,3,0),jacCurvToCart(n,3,1),jacCurvToCart(n,3,2),jacCurvToCart(n,3,3),jacCurvToCart(n,3,4),jacCurvToCart(n,3,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,4,0),jacCurvToCart(n,4,1),jacCurvToCart(n,4,2),jacCurvToCart(n,4,3),jacCurvToCart(n,4,4),jacCurvToCart(n,4,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvToCart(n,5,0),jacCurvToCart(n,5,1),jacCurvToCart(n,5,2),jacCurvToCart(n,5,3),jacCurvToCart(n,5,4),jacCurvToCart(n,5,5));
+        }
 #endif
 
         // calculate transport matrix
@@ -665,48 +674,60 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         jacCurvProp(n,4,4) = (v11*v21 + v12*v22 + v13*v23);
 
 #ifdef DEBUG
-	std::cout << "jacCurvProp" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,0,0),jacCurvProp(n,0,1),jacCurvProp(n,0,2),jacCurvProp(n,0,3),jacCurvProp(n,0,4),jacCurvProp(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,1,0),jacCurvProp(n,1,1),jacCurvProp(n,1,2),jacCurvProp(n,1,3),jacCurvProp(n,1,4),jacCurvProp(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,2,0),jacCurvProp(n,2,1),jacCurvProp(n,2,2),jacCurvProp(n,2,3),jacCurvProp(n,2,4),jacCurvProp(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,3,0),jacCurvProp(n,3,1),jacCurvProp(n,3,2),jacCurvProp(n,3,3),jacCurvProp(n,3,4),jacCurvProp(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,4,0),jacCurvProp(n,4,1),jacCurvProp(n,4,2),jacCurvProp(n,4,3),jacCurvProp(n,4,4),jacCurvProp(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,5,0),jacCurvProp(n,5,1),jacCurvProp(n,5,2),jacCurvProp(n,5,3),jacCurvProp(n,5,4),jacCurvProp(n,5,5));
+        {
+          dmutex;
+        	std::cout << "jacCurvProp" << std::endl;
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,0,0),jacCurvProp(n,0,1),jacCurvProp(n,0,2),jacCurvProp(n,0,3),jacCurvProp(n,0,4),jacCurvProp(n,0,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,1,0),jacCurvProp(n,1,1),jacCurvProp(n,1,2),jacCurvProp(n,1,3),jacCurvProp(n,1,4),jacCurvProp(n,1,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,2,0),jacCurvProp(n,2,1),jacCurvProp(n,2,2),jacCurvProp(n,2,3),jacCurvProp(n,2,4),jacCurvProp(n,2,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,3,0),jacCurvProp(n,3,1),jacCurvProp(n,3,2),jacCurvProp(n,3,3),jacCurvProp(n,3,4),jacCurvProp(n,3,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,4,0),jacCurvProp(n,4,1),jacCurvProp(n,4,2),jacCurvProp(n,4,3),jacCurvProp(n,4,4),jacCurvProp(n,4,5));
+        	printf("%5f %5f %5f %5f %5f %5f\n", jacCurvProp(n,5,0),jacCurvProp(n,5,1),jacCurvProp(n,5,2),jacCurvProp(n,5,3),jacCurvProp(n,5,4),jacCurvProp(n,5,5));
+        }
 #endif
 
 	MPlexLL temp5;
 	MultHelixPropFull(jacCartToCurv, rotateCartCa2Cu, temp5);
 #ifdef DEBUG
-	std::cout << "rotated jacCartToCurv" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,0,0),temp5(n,0,1),temp5(n,0,2),temp5(n,0,3),temp5(n,0,4),temp5(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,1,0),temp5(n,1,1),temp5(n,1,2),temp5(n,1,3),temp5(n,1,4),temp5(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,2,0),temp5(n,2,1),temp5(n,2,2),temp5(n,2,3),temp5(n,2,4),temp5(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,3,0),temp5(n,3,1),temp5(n,3,2),temp5(n,3,3),temp5(n,3,4),temp5(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,4,0),temp5(n,4,1),temp5(n,4,2),temp5(n,4,3),temp5(n,4,4),temp5(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,5,0),temp5(n,5,1),temp5(n,5,2),temp5(n,5,3),temp5(n,5,4),temp5(n,5,5));
+  {
+    dmutex;
+  	std::cout << "rotated jacCartToCurv" << std::endl;
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,0,0),temp5(n,0,1),temp5(n,0,2),temp5(n,0,3),temp5(n,0,4),temp5(n,0,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,1,0),temp5(n,1,1),temp5(n,1,2),temp5(n,1,3),temp5(n,1,4),temp5(n,1,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,2,0),temp5(n,2,1),temp5(n,2,2),temp5(n,2,3),temp5(n,2,4),temp5(n,2,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,3,0),temp5(n,3,1),temp5(n,3,2),temp5(n,3,3),temp5(n,3,4),temp5(n,3,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,4,0),temp5(n,4,1),temp5(n,4,2),temp5(n,4,3),temp5(n,4,4),temp5(n,4,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp5(n,5,0),temp5(n,5,1),temp5(n,5,2),temp5(n,5,3),temp5(n,5,4),temp5(n,5,5));
+  }
 #endif
 	MPlexLL temp6;
 	MultHelixPropFull(rotateCartCu2Ca, jacCurvToCart, temp6);
 #ifdef DEBUG
-	std::cout << "rotated jacCurvToCart" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,0,0),temp6(n,0,1),temp6(n,0,2),temp6(n,0,3),temp6(n,0,4),temp6(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,1,0),temp6(n,1,1),temp6(n,1,2),temp6(n,1,3),temp6(n,1,4),temp6(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,2,0),temp6(n,2,1),temp6(n,2,2),temp6(n,2,3),temp6(n,2,4),temp6(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,3,0),temp6(n,3,1),temp6(n,3,2),temp6(n,3,3),temp6(n,3,4),temp6(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,4,0),temp6(n,4,1),temp6(n,4,2),temp6(n,4,3),temp6(n,4,4),temp6(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,5,0),temp6(n,5,1),temp6(n,5,2),temp6(n,5,3),temp6(n,5,4),temp6(n,5,5));
+  {
+    dmutex;
+  	std::cout << "rotated jacCurvToCart" << std::endl;
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,0,0),temp6(n,0,1),temp6(n,0,2),temp6(n,0,3),temp6(n,0,4),temp6(n,0,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,1,0),temp6(n,1,1),temp6(n,1,2),temp6(n,1,3),temp6(n,1,4),temp6(n,1,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,2,0),temp6(n,2,1),temp6(n,2,2),temp6(n,2,3),temp6(n,2,4),temp6(n,2,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,3,0),temp6(n,3,1),temp6(n,3,2),temp6(n,3,3),temp6(n,3,4),temp6(n,3,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,4,0),temp6(n,4,1),temp6(n,4,2),temp6(n,4,3),temp6(n,4,4),temp6(n,4,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", temp6(n,5,0),temp6(n,5,1),temp6(n,5,2),temp6(n,5,3),temp6(n,5,4),temp6(n,5,5));
+  }
 #endif
 	MPlexLL temp7;
 	MultHelixPropFull(jacCurvProp, temp5, temp7);
 	MultHelixPropFull(temp6, temp7, errorProp);
 #ifdef DEBUG
-	std::cout << "jacobian iterative" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+  {
+    dmutex;
+  	std::cout << "jacobian iterative" << std::endl;
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
+  	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+  }
 #endif
 
       } else if (Config::useSimpleJac) { 
@@ -770,13 +791,16 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
       }
 
 #ifdef DEBUG
-      std::cout << "jacobian iterative" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+      {
+        dmutex;
+        std::cout << "jacobian iterative" << std::endl;
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+      }
 #endif
     }
 }
@@ -932,13 +956,16 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
       computeJacobianSimple(n, errorProp, k, TP, cosTP, sinTP);
 
 #ifdef DEBUG
-      std::cout << "jacobian intersection" << std::endl;
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
-      printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+      {
+        dmutex;
+        std::cout << "jacobian intersection" << std::endl;
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
+        printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
+      }
 #endif
     }
 }
@@ -1020,7 +1047,7 @@ void propagateHelixToRMPlex(const MPlexLS &inErr,  const MPlexLV& inPar,
 			          MPlexLS &outErr,       MPlexLV& outPar)
 {
 #ifdef DEBUG
-  const bool dump = false;
+  const bool debug = false;
 #endif
 
    const idx_t N  = NN;
@@ -1055,18 +1082,18 @@ void propagateHelixToRMPlex(const MPlexLS &inErr,  const MPlexLV& inPar,
    }
 
 #ifdef DEBUG
-   if (dump) {
+   if (debug) {
      for (int kk = 0; kk < N; ++kk)
      {
-       printf("outErr before prop %d\n", kk);
+       dprintf("outErr before prop %d\n", kk);
        for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-           printf("%8f ", outErr.At(kk,i,j)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", outErr.At(kk,i,j)); printf("\n");
+       } dprintf("\n");
 
-       printf("errorProp %d\n", kk);
+       dprintf("errorProp %d\n", kk);
        for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-           printf("%8f ", errorProp.At(kk,i,j)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", errorProp.At(kk,i,j)); printf("\n");
+       } dprintf("\n");
 
      }
    }
@@ -1089,27 +1116,27 @@ void propagateHelixToRMPlex(const MPlexLS &inErr,  const MPlexLV& inPar,
 
    // This dump is now out of its place as similarity is done with matriplex ops.
 #ifdef DEBUG
-   if (dump) {
+   if (debug) {
      for (int kk = 0; kk < N; ++kk)
      {
-       printf("outErr %d\n", kk);
+       dprintf("outErr %d\n", kk);
        for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-           printf("%8f ", outErr.At(kk,i,j)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", outErr.At(kk,i,j)); printf("\n");
+       } dprintf("\n");
 
-       printf("outPar %d\n", kk);
+       dprintf("outPar %d\n", kk);
        for (int i = 0; i < 6; ++i) {
-           printf("%8f ", outPar.At(kk,i,0)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", outPar.At(kk,i,0)); printf("\n");
+       } dprintf("\n");
      }
    }
 #endif
 
 #ifdef DEBUG
    if (fabs(hipo(outPar.At(0,0,0), outPar.At(0,1,0))-hipo(msPar.ConstAt(0, 0, 0), msPar.ConstAt(0, 1, 0)))>0.0001) {
-     std::cout << "DID NOT GET TO R, dR=" << fabs(hipo(outPar.At(0,0,0), outPar.At(0,1,0))-hipo(msPar.ConstAt(0, 0, 0), msPar.ConstAt(0, 1, 0)))
-	       << " r=" << hipo(msPar.ConstAt(0, 0, 0), msPar.ConstAt(0, 1, 0)) << " r0in=" << hipo(inPar.ConstAt(0,0,0), inPar.ConstAt(0,1,0)) << " rout=" << hipo(outPar.At(0,0,0), outPar.At(0,1,0)) << std::endl;
-     std::cout << "pt=" << hipo(inPar.ConstAt(0,3,0), inPar.ConstAt(0,4,0)) << " pz=" << inPar.ConstAt(0,5,0) << std::endl;
+     dprint("DID NOT GET TO R, dR=" << fabs(hipo(outPar.At(0,0,0), outPar.At(0,1,0))-hipo(msPar.ConstAt(0, 0, 0), msPar.ConstAt(0, 1, 0)))
+	       << " r=" << hipo(msPar.ConstAt(0, 0, 0), msPar.ConstAt(0, 1, 0)) << " r0in=" << hipo(inPar.ConstAt(0,0,0), inPar.ConstAt(0,1,0)) << " rout=" << hipo(outPar.At(0,0,0), outPar.At(0,1,0)) << std::endl
+         << "pt=" << hipo(inPar.ConstAt(0,3,0), inPar.ConstAt(0,4,0)) << " pz=" << inPar.ConstAt(0,5,0));
    }
 #endif
 }
@@ -1120,7 +1147,7 @@ void propagateHelixToRMPlex(const MPlexLS& inErr,  const MPlexLV& inPar,
                             const int      N_proc)
 {
 #ifdef DEBUG
-  const bool dump = false;
+  const bool debug = false;
 #endif
 
    outErr = inErr;
@@ -1167,18 +1194,18 @@ void propagateHelixToRMPlex(const MPlexLS& inErr,  const MPlexLV& inPar,
    
    // This dump is now out of its place as similarity is done with matriplex ops.
 #ifdef DEBUG
-   if (dump) {
+   if (debug) {
      for (int kk = 0; kk < N_proc; ++kk)
      {
-       printf("outErr %d\n", kk);
+       dprintf("outErr %d\n", kk);
        for (int i = 0; i < 6; ++i) { for (int j = 0; j < 6; ++j)
-           printf("%8f ", outErr.At(kk,i,j)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", outErr.At(kk,i,j)); printf("\n");
+       } dprintf("\n");
 
-       printf("outPar %d\n", kk);
+       dprintf("outPar %d\n", kk);
        for (int i = 0; i < 6; ++i) {
-           printf("%8f ", outPar.At(kk,i,0)); printf("\n");
-       } printf("\n");
+           dprintf("%8f ", outPar.At(kk,i,0)); printf("\n");
+       } dprintf("\n");
      }
    }
 #endif

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -1,5 +1,8 @@
 #include "PropagationMPlex.h"
 
+//#define DEBUG
+#include "Debug.h"
+
 //==============================================================================
 // propagateLineToRMPlex
 //==============================================================================
@@ -21,9 +24,7 @@ void propagateLineToRMPlex(const MPlexLS &psErr,  const MPlexLV& psPar,
      const float cosA = (psPar[0 * N + n] * psPar[3 * N + n] + psPar[1 * N + n] * psPar[4 * N + n]) / ( sqrt( ( psPar[0 * N + n] * psPar[0 * N + n] + psPar[1 * N + n] * psPar[1 * N + n] ) * ( psPar[3 * N + n] * psPar[3 * N + n] + psPar[4 * N + n] * psPar[4 * N + n] ) ) );
      const float dr  = (hipo(msPar[0 * N + n], msPar[1 * N + n]) - hipo(psPar[0 * N + n], psPar[1 * N + n])) / cosA;
 
-#ifdef DEBUG
-     std::cout << "propagateLineToRMPlex dr=" << dr << std::endl;
-#endif
+     dprint("propagateLineToRMPlex dr=" << dr);
 
       const float pt  = hipo(psPar[3 * N + n], psPar[4 * N + n]);
       const float p   = dr / pt; // path
@@ -63,10 +64,7 @@ void propagateLineToRMPlex(const MPlexLS &psErr,  const MPlexLV& psPar,
         B.fArray[20 * N + n] = A.fArray[20 * N + n] + p * (A.fArray[17 * N + n] + A.fArray[17 * N + n]) + psq * A.fArray[5 * N + n];
       }
 
-#ifdef DEBUG
-      std::cout << "propagateLineToRMPlex arrive at r=" << hipo(outPar[0 * N + n], outPar[1 * N + n]) << std::endl;
-#endif
-
+      dprint("propagateLineToRMPlex arrive at r=" << hipo(outPar[0 * N + n], outPar[1 * N + n]));
    }
 }
 
@@ -233,10 +231,9 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
       const float& r    = msRad.ConstAt(n, 0, 0);
       float r0 = hipo(xin, yin);
       
+      dprint(std::endl << "attempt propagation from r=" << r0 << " to r=" << r << std::endl
+        << "x=" << xin << " y=" << yin  << " z=" << inPar.ConstAt(n, 2, 0) << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inChg.ConstAt(n, 0, 0));
 #ifdef DEBUG
-      std::cout << std::endl;
-      std::cout << "attempt propagation from r=" << r0 << " to r=" << r << std::endl;
-      std::cout << "x=" << xin << " y=" << yin  << " z=" << inPar.ConstAt(n, 2, 0) << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inChg.ConstAt(n, 0, 0) << std::endl;
       // if ((r0-r)>=0) {
       //    if (dump) std::cout << "target radius same or smaller than starting point, returning input" << std::endl;
       //    return;
@@ -244,9 +241,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 #endif
 
       if (fabs(r-r0)<0.0001) {
-#ifdef DEBUG
-	std::cout << "distance less than 1mum, skip" << std::endl;
-#endif
+	dprint("distance less than 1mum, skip");
 	computeJacobianSimple(n, errorProp, 1, 0, 1, 0);//get an identity matrix
 	continue;
       }
@@ -260,9 +255,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
       float invcurvature = 1./(pt*k);//in 1./cm
       float ctgTheta=pzin*ptinv;
       
-#ifdef DEBUG
-      std::cout << "curvature=" << 1./invcurvature << std::endl;
-#endif
+      dprint("curvature=" << 1./invcurvature);
       
       //variables to be updated at each iterations
       float totalDistance = 0;
@@ -289,9 +282,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
       // const unsigned int Niter = 5+std::round(r-r0)/2;
       for (unsigned int i=0;i<Config::Niter;++i)
 	{
-#ifdef DEBUG
-	  std::cout << "propagation iteration #" << i << std::endl;
-#endif
+	  dprint("propagation iteration #" << i);
 	  
 	  x  = outPar.At(n, 0, 0);
 	  y  = outPar.At(n, 1, 0);
@@ -299,8 +290,8 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	  py = outPar.At(n, 4, 0);
 	  r0 = hipo(outPar.At(n, 0, 0), outPar.At(n, 1, 0));
 	  
+	  dprint("r0=" << r0 << " pt=" << pt);
 #ifdef DEBUG
-	  std::cout << "r0=" << r0 << " pt=" << pt << std::endl;
 	  // if (dump) {
 	  //    if (r==r0) {
 	  //       std::cout << "distance = 0 at iteration=" << i << std::endl;
@@ -312,9 +303,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	  //distance=r-r0;//remove temporary
 	  totalDistance+=(r-r0);
 	  
-#ifdef DEBUG
-	  std::cout << "distance=" << (r-r0) << " angPath=" << (r-r0)*invcurvature << std::endl;
-#endif
+	  dprint("distance=" << (r-r0) << " angPath=" << (r-r0)*invcurvature);
 	  
 	  //float angPath = (r-r0)*invcurvature;
 	  if (Config::useTrigApprox) {
@@ -339,9 +328,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	     //now r0 depends on px and py
 	     r0 = 1./r0;//WARNING, now r0 is r0inv (one less temporary)
 
-#ifdef DEBUG
-	     std::cout << "r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt << std::endl;
-#endif
+	     dprint("r0=" << 1./r0 << " r0inv=" << r0 << " pt=" << pt);
 
 	     //update derivative on D
 	     dAPdx = -x*r0*invcurvature;
@@ -369,22 +356,18 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 
 	  }
 	  
-#ifdef DEBUG
-	  std::cout << "iteration end, dump parameters" << std::endl;
-	  std::cout << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl;
-	  std::cout << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0) << std::endl;
-	  std::cout << "r=" << sqrt( outPar.At(n, 0, 0)*outPar.At(n, 0, 0) + outPar.At(n, 1, 0)*outPar.At(n, 1, 0) ) << " pT=" << sqrt( outPar.At(n, 3, 0)*outPar.At(n, 3, 0) + outPar.At(n, 4, 0)*outPar.At(n, 4, 0) ) << std::endl;
-#endif
+	  dprint("iteration end, dump parameters" << std::endl
+      << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl
+	    << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0) << std::endl
+	    << "r=" << sqrt( outPar.At(n, 0, 0)*outPar.At(n, 0, 0) + outPar.At(n, 1, 0)*outPar.At(n, 1, 0) ) << " pT=" << sqrt( outPar.At(n, 3, 0)*outPar.At(n, 3, 0) + outPar.At(n, 4, 0)*outPar.At(n, 4, 0) ));
 	}
       
       float& TD=totalDistance;
       float  TP=TD*invcurvature;//totalAngPath
       
-#ifdef DEBUG
-      std::cout << "TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(outPar.At(n, 0, 0)*outPar.At(n, 0, 0)+outPar.At(n, 1, 0)*outPar.At(n, 1, 0)) << std::endl;
-      std::cout << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl;
-      std::cout << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0) << std::endl;
-#endif
+      dprint("TD=" << TD << " TP=" << TP << " arrived at r=" << sqrt(outPar.At(n, 0, 0)*outPar.At(n, 0, 0)+outPar.At(n, 1, 0)*outPar.At(n, 1, 0)) << std::endl
+        << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl
+        << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0));
 
       float& iC=invcurvature;
       float dCdpx = k*pxin*ptinv;
@@ -402,13 +385,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
 	sinTP = sin(TP);
       }
 
-#ifdef DEBUG
-      std::cout 
-	<< "sinTP=" << sinTP
-	<< " cosTP=" << cosTP
-	<< " TD=" << TD
-	<< std::endl;
-#endif
+      dprint("sinTP=" << sinTP << " cosTP=" << cosTP << " TD=" << TD);
 
       if (Config::useCurvJac) {
 
@@ -522,9 +499,7 @@ void helixAtRFromIterative(const MPlexLV& inPar, const MPlexQI& inChg, MPlexLV& 
         float sinphi = py/pt;
         float cosphi = px/pt;
 	
-#ifdef DEBUG
-        std::cout << "q=" << q << " p2=" << p2 << " coslambda=" << coslambda << " cosphi=" << cosphi << std::endl;
-#endif
+        dprint("q=" << q << " p2=" << p2 << " coslambda=" << coslambda << " cosphi=" << cosphi);
 	
         jacCurvToCart(n,1,3) = 1.;
         jacCurvToCart(n,2,4) = 1.;
@@ -820,9 +795,9 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
       const float& rout = msRad.ConstAt(n, 0, 0);
       const float r0in = hipo(xin, yin);
       
+      dprint("attempt propagation from r=" << r0in << " to r=" << rout << std::endl
+        << "x=" << xin << " y=" << yin  << " z=" << inPar.ConstAt(n, 2, 0) << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inChg.ConstAt(n, 0, 0));
 #ifdef DEBUG
-      std::cout << "attempt propagation from r=" << r0in << " to r=" << rout << std::endl;
-      std::cout << "x=" << xin << " y=" << yin  << " z=" << inPar.ConstAt(n, 2, 0) << " px=" << pxin << " py=" << pyin << " pz=" << pzin << " q=" << inChg.ConstAt(n, 0, 0) << std::endl;
       // if ((r0in-r)>=0) {
       //    if (dump) std::cout << "target radius same or smaller than starting point, returning input" << std::endl;
       //    return;
@@ -830,9 +805,7 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
 #endif
 
       if (fabs(rout-r0in)<0.0001) {
-#ifdef DEBUG
-	std::cout << "distance less than 1mum, skip" << std::endl;
-#endif
+	dprint("distance less than 1mum, skip");
 	computeJacobianSimple(n, errorProp, 1, 0, 1, 0);//get an identity matrix
 	continue;
       }
@@ -846,9 +819,7 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
       float curvature = pt*k;//in cm
       float invcurvature = 1./(curvature);//in 1./cm
       
-#ifdef DEBUG
-      std::cout << "k=" << k << " curvature=" << curvature << " invcurvature=" << invcurvature << std::endl;
-#endif
+      dprint("k=" << k << " curvature=" << curvature << " invcurvature=" << invcurvature);
       
       //coordinates of center of circle defined as helix projection on transverse plane 
       float xc = xin - k*pyin;
@@ -869,13 +840,11 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
 	float x_m = ( -B - sqrt(B*B - 4*A*C) ) / (2*A);
 	float y_m = -x_m*xc/yc + (rout*rout + rc*rc - curvature*curvature)/(2*yc);
 	float cosDelta_m = (pxin*(x_m-xin) + pyin*(y_m-yin))/(pt*sqrt((x_m-xin)*(x_m-xin)+(y_m-yin)*(y_m-yin)));
-#ifdef DEBUG
-	std::cout << "solve for x" << std::endl;
-	std::cout << "xc=" << xc << " yc=" << yc << " rc=" << rc << std::endl;
-	std::cout << "A=" << A << " B=" << B << " C=" << C << std::endl;
-	std::cout << "xp=" << x_p << " y_p=" << y_p << " cosDelta_p=" << cosDelta_p << std::endl;
-	std::cout << "xm=" << x_m << " y_m=" << y_m << " cosDelta_m=" << cosDelta_m << std::endl;
-#endif 
+	dprint("solve for x" << std::endl
+	  << "xc=" << xc << " yc=" << yc << " rc=" << rc << std::endl
+	  << "A=" << A << " B=" << B << " C=" << C << std::endl
+	  << "xp=" << x_p << " y_p=" << y_p << " cosDelta_p=" << cosDelta_p << std::endl
+	  << "xm=" << x_m << " y_m=" << y_m << " cosDelta_m=" << cosDelta_m);
 	float Sx = sqrt(B*B - 4*A*C);
 	//arbitrate based on momentum and vector connecting the end points
 	if ( (rout>r0in) ? (cosDelta_p > cosDelta_m) : (cosDelta_p < cosDelta_m)) { 
@@ -884,20 +853,14 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
 	  TP = 2*asin(sinTPHalf_p);
 	  x = x_p;
 	  y = y_p;
-#ifdef DEBUG
-	  std::cout << "pos solution" << std::endl;
-	  std::cout << "chord_p=" << chord_p << " sinTPHalf_p=" << sinTPHalf_p << " TP=" << TP << std::endl;
-#endif
+	  dprint("pos solution" << std::endl << "chord_p=" << chord_p << " sinTPHalf_p=" << sinTPHalf_p << " TP=" << TP);
 	} else {
 	  float chord_m = sqrt( (x_m-xin)*(x_m-xin) + (y_m-yin)*(y_m-yin) );
 	  float sinTPHalf_m = 0.5*chord_m*invcurvature;
 	  TP = 2*asin(sinTPHalf_m);
 	  x = x_m;
 	  y = y_m;
-#ifdef DEBUG
-	  std::cout << "neg solution" << std::endl;
-	  std::cout << "chord_m=" << chord_m << " sinTPHalf_m=" << sinTPHalf_m << " TP=" << TP << std::endl;
-#endif
+	  dprint("neg solution" << std::endl << "chord_m=" << chord_m << " sinTPHalf_m=" << sinTPHalf_m << " TP=" << TP);
 	} 
       } else {
 	//solve for y since xc!=0
@@ -912,13 +875,11 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
 	float y_m = ( -B - sqrt(B*B - 4*A*C) ) / (2*A);
 	float x_m = -y_m*yc/xc + (rout*rout + rc*rc - curvature*curvature)/(2*xc);
 	float cosDelta_m = (pxin*(x_m-xin) + pyin*(y_m-yin))/(pt*sqrt((x_m-xin)*(x_m-xin)+(y_m-yin)*(y_m-yin)));
-#ifdef DEBUG
-	std::cout << "solve for y" << std::endl;
-	std::cout << "xc=" << xc << " yc=" << yc << " rc=" << rc << std::endl;
-	std::cout << "A=" << A << " B=" << B << " C=" << C << std::endl;
-	std::cout << "xp=" << x_p << " y_p=" << y_p << " cosDelta_p=" << cosDelta_p << std::endl;
-	std::cout << "xm=" << x_m << " y_m=" << y_m << " cosDelta_m=" << cosDelta_m << std::endl;
-#endif
+	dprint("solve for y" << std::endl
+	  << "xc=" << xc << " yc=" << yc << " rc=" << rc << std::endl
+	  << "A=" << A << " B=" << B << " C=" << C << std::endl
+	  << "xp=" << x_p << " y_p=" << y_p << " cosDelta_p=" << cosDelta_p << std::endl
+	  << "xm=" << x_m << " y_m=" << y_m << " cosDelta_m=" << cosDelta_m);
 	float Sx = sqrt(B*B - 4*A*C);
 	//arbitrate based on momentum and vector connecting the end points
 	if ( (rout>r0in) ? (cosDelta_p > cosDelta_m) : (cosDelta_p < cosDelta_m)) { 
@@ -960,12 +921,10 @@ void helixAtRFromIntersection(const MPlexLV& inPar, const MPlexQI& inChg, MPlexL
       outPar.At(n, 4, 0) = pyin*cosTP+pxin*sinTP;
       //outPar.At(n, 5, 0) = pzin; //take this out as it is redundant
 
-#ifdef DEBUG
-      std::cout << "propagation end, dump parameters" << std::endl;
-      std::cout << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl;
-      std::cout << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0) << std::endl;
-      std::cout << "r=" << sqrt( outPar.At(n, 0, 0)*outPar.At(n, 0, 0) + outPar.At(n, 1, 0)*outPar.At(n, 1, 0) ) << " pT=" << sqrt( outPar.At(n, 3, 0)*outPar.At(n, 3, 0) + outPar.At(n, 4, 0)*outPar.At(n, 4, 0) ) << std::endl;
-#endif
+      dprint("propagation end, dump parameters" << std::endl
+        << "pos = " << outPar.At(n, 0, 0) << " " << outPar.At(n, 1, 0) << " " << outPar.At(n, 2, 0) << std::endl
+        << "mom = " << outPar.At(n, 3, 0) << " " << outPar.At(n, 4, 0) << " " << outPar.At(n, 5, 0) << std::endl
+        << "r=" << sqrt( outPar.At(n, 0, 0)*outPar.At(n, 0, 0) + outPar.At(n, 1, 0)*outPar.At(n, 1, 0) ) << " pT=" << sqrt( outPar.At(n, 3, 0)*outPar.At(n, 3, 0) + outPar.At(n, 4, 0)*outPar.At(n, 4, 0) ));
 
       float p = pt2 + pzin*pzin;
       p=sqrt(p);

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -187,7 +187,7 @@ void buildSeedsByRoadTriplets(TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed
   if (debug){
     dprint("Hit Pairs");
     for(auto&& hitPair : hitPairs){
-      printf("ilay0: %1u ilay1: %1u  \n",
+      dprintf("ilay0: %1u ilay1: %1u  \n",
  	     ev.simHitsInfo_[evt_lay_hits[0][hitPair[0]].mcHitID()].mcTrackID(),
  	     ev.simHitsInfo_[evt_lay_hits[1][hitPair[1]].mcHitID()].mcTrackID()
 	     );
@@ -216,7 +216,7 @@ void buildSeedsByRoadTriplets(TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed
   if (debug){
     dprint("Hit Triplets");
     for(auto&& hitTriplet : hitTriplets){
-      printf("ilay0: %1u ilay1: %1u ilay2: %1u \n",
+      dprintf("ilay0: %1u ilay1: %1u ilay2: %1u \n",
  	     ev.simHitsInfo_[evt_lay_hits[0][hitTriplet[0]].mcHitID()].mcTrackID(),
  	     ev.simHitsInfo_[evt_lay_hits[1][hitTriplet[1]].mcHitID()].mcTrackID(),
  	     ev.simHitsInfo_[evt_lay_hits[2][hitTriplet[2]].mcHitID()].mcTrackID()

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -217,7 +217,7 @@ void buildSeedsByRoadTriplets(TrackVec& evt_seed_tracks, TrackExtraVec& evt_seed
     for(auto&& hitTriplet : hitTriplets){
       printf("ilay0: %1u ilay1: %1u ilay2: %1u \n",
  	     ev.simHitsInfo_[evt_lay_hits[0][hitTriplet[0]].mcHitID()].mcTrackID(),
- 	     ev.simHitsInfo_[evt_lay_hits[1][hitTriplet[1]].mcHitID()].mcTrackID()
+ 	     ev.simHitsInfo_[evt_lay_hits[1][hitTriplet[1]].mcHitID()].mcTrackID(),
  	     ev.simHitsInfo_[evt_lay_hits[2][hitTriplet[2]].mcHitID()].mcTrackID()
 	     );
     }
@@ -323,7 +323,7 @@ void buildHitTripletsCurve(const std::vector<HitVec>& evt_lay_hits, const BinInf
     const auto phiBinMinus = getPhiPartition(negPhi);
     const auto phiBinPlus  = getPhiPartition(posPhi);
 
-#ifdef DEBUG
+#ifdef BROKEN_DEBUG
     const float lay2phi = evt_lay_hits[2][ev.simTracks_[ev.simHitsInfo_[hit0.mcHitID()].mcTrackID()].getHitIdx(2)].phi();
     dprint("lay0 phi: " << hit0.phi() << " lay1 phi: " << hit1.phi() << std::endl <<
 	   "negPhi: " << negPhi << " lay2 phi: " << lay2phi << " posPhi: " << posPhi << std::endl <<


### PR DESCRIPTION
Cleanup and standardize debug statements.  Touches lots of files but no algorithm changes, all changes are inside DEBUG defines.  Uses dprint()/dcall()/dprintf() macros to try to eliminate "#ifdef DEBUG" where reasonable, standardizes on "debug" bool (changing "dump" to "debug" in places), and adds a C++11 mutex for all debug statements (replacing the OMP mutex in MkBuilder).  Most extensive changes are in MkBuilder due to consolidation of cut&paste print statements into print routines, changes to other files are all pretty straightforward.  Has been test compiled with (and without) -DDEBUG with icc and clang.  Since there are no algorithmic changes, did not run benchmarks.