### PR TITLE
Some minor changes to CF MPlex port

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -26,6 +26,8 @@ namespace Config
   bool  useCMSGeom = false;
   bool  readCmsswSeeds = false;
 
-  bool  super_debug = false;
   bool  cf_seeding  = false;
+  bool  cf_fitting  = false;
+
+  bool  super_debug = false;
 }

--- a/Config.h
+++ b/Config.h
@@ -17,6 +17,7 @@ namespace Config
   constexpr float TwoPI    = 6.28318530717958647692;
   constexpr float PIOver2  = Config::PI / 2.0;
   constexpr float PIOver4  = Config::PI / 4.0;
+  constexpr float PI3Over4 = 3.0 * Config::PI / 4.0;
   constexpr float InvPI    = 1.0 / Config::PI;
   constexpr float RadToDeg = 180.0 / Config::PI;
   constexpr float DegToRad = Config::PI / 180.0;
@@ -124,9 +125,9 @@ namespace Config
   constexpr float phierr049   = 0.0017; // 0.0017;
   constexpr float thetaerr049 = 0.0033; // 0.0031; 
   // parameters for layers 0,1,2 // --> ENDTOEND with "real seeding", fit is outward by definition, with poly geo
-  constexpr float ptinverr012 = 0.1234; // 0.1789;  -->old values from only MC seeds
-  constexpr float phierr012   = 0.0071; // 0170; 
-  constexpr float thetaerr012 = 0.0130; // 0.0137; 
+  constexpr float ptinverr012 = 0.12007; // 0.1789;  -->old values from only MC seeds
+  constexpr float phierr012   = 0.00646; // 0.0071 
+  constexpr float thetaerr012 = 0.01366; // 0.0130; 
 
   // matrix config
   // XXXX MT this should be renamed, made constexpr

--- a/Config.h
+++ b/Config.h
@@ -10,7 +10,6 @@ namespace Config
 {
   // super debug mode in SMatrix
   extern bool super_debug;
-  extern bool cf_seeding;
 
   // math general --> from namespace TMath
   constexpr float    PI    = 3.14159265358979323846;
@@ -85,7 +84,8 @@ namespace Config
   constexpr float seed_z0cut   = beamspotZ * 3.0; // 3cm
   constexpr float lay2Zcut     = hitposerrZ * 3.6; // 3.6 mm --> to match efficiency from chi2cut
   constexpr float seed_d0cut   = 0.5; // 5mm
-  
+  extern bool cf_seeding;
+
   // Config for propagation
   constexpr int Niter = 5;
   constexpr float Bfield = 3.8112;
@@ -128,6 +128,9 @@ namespace Config
   constexpr float ptinverr012 = 0.12007; // 0.1789;  -->old values from only MC seeds
   constexpr float phierr012   = 0.00646; // 0.0071 
   constexpr float thetaerr012 = 0.01366; // 0.0130; 
+
+  // config on fitting
+  extern bool cf_fitting;
 
   // matrix config
   // XXXX MT this should be renamed, made constexpr

--- a/ConformalUtils.cc
+++ b/ConformalUtils.cc
@@ -18,10 +18,21 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
   z[1]=hit1.position()[2];
   z[2]=hit2.position()[2];
 
-  float u[3],v[3];
-  for (unsigned int h=0;h<3;++h) {
-    u[h]=x[h]/(x[h]*x[h]+y[h]*y[h]);
-    v[h]=y[h]/(x[h]*x[h]+y[h]*y[h]);
+  float u[3],v[3]; // conformal points
+  float initphi = abs(atan2(y[1],x[1])); // use this to decide when to use x -> u or x -> v
+  bool xtou = (initphi<Config::PIOver4 || initPhi>Config::PI3Over4);
+
+  if (xtou){ // x -> u 
+    for (unsigned int h=0;h<3;++h) {
+      u[h]=x[h]/getRad2(x[h],y[h]);
+      v[h]=y[h]/getRad2(x[h],y[h]);
+    }
+  }
+  else { // x -> v
+    for (unsigned int h=0;h<3;++h) {
+      v[h]=x[h]/getRad2(x[h],y[h]);
+      u[h]=y[h]/getRad2(x[h],y[h]);
+    }
   }
 
   //R^2=a^2+b^2
@@ -36,34 +47,25 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
 
   float b=1./(2.*C[0]);
   float a=b*C[1];
-  float R=sqrt((x[0]-a)*(x[0]-a)+(y[0]-b)*(y[0]-b));
+
+  // Special note, "vr" is short for vector, not vertex!           
+  // evaluate momentum, phi, theta at layer one
+  // taking vector from center of circle to layer one position
+  // therefore phi is the perpendicular to vector just described        
+
+  float vrx = (xtou ? x[0]-a : x[0]-b);
+  float vry = (xtou ? y[0]-b : y[0]-a);
+
+  float R   = sqrtf(getRad2(vrx,vry));
   //float e=b*b*b*C[2]/(R*R*R);
-
-  float k=charge*100./(-Config::sol*Config::Bfield);
-  float pt = R/k;
-  /*
-  std::cout << "hit0=" << x[0] << "," << y[0] << std::endl;
-  std::cout << "hit1=" << x[1] << "," << y[1] << std::endl;
-  std::cout << "hit2=" << x[2] << "," << y[2] << std::endl;
-  std::cout << "hit0t=" << u[0] << "," << v[0] << std::endl;
-  std::cout << "hit1t=" << u[1] << "," << v[1] << std::endl;
-  std::cout << "hit2t=" << u[2] << "," << v[2] << std::endl;
-  std::cout << "vfit0=" << C[0]-u[0]*C[1]-u[0]*u[0]*C[2] << std::endl;
-  std::cout << "vfit1=" << C[0]-u[1]*C[1]-u[1]*u[1]*C[2] << std::endl;
-  std::cout << "vfit2=" << C[0]-u[2]*C[1]-u[2]*u[2]*C[2] << std::endl;
-  std::cout << "c0=" << C[0] << " c1=" << C[1] << " c2=" << C[2] << std::endl;
-  std::cout << "a=" << a << " b=" << b << " e=" << e << std::endl;
-  std::cout << "R=" << R << " pt=" << pt << std::endl;
-  */
-
-  float vrx = x[0]-a;
-  float vry = y[0]-b;
-  float phi = atan2(vrx,vry);
-  float px = fabs(pt*cos(phi))*((x[1]-x[0])>0. ? 1. : -1.);
-  float py = fabs(pt*sin(phi))*((y[1]-y[0])>0. ? 1. : -1.);
+  float k   = charge*100./(-Config::sol*Config::Bfield);
+  float pt  = R/k;
+  float phi = getPhi(vry,vrx);
+  float px  = fabs(pt*cos(phi))*((x[1]-x[0])>0. ? 1. : -1.);
+  float py  = fabs(pt*sin(phi))*((y[1]-y[0])>0. ? 1. : -1.);
 
   //compute theta
-  float tantheta = sqrt((x[0]-x[2])*(x[0]-x[2])+(y[0]-y[2])*(y[0]-y[2]))/(z[2]-z[0]);
+  float tantheta = sqrtf(getRad2((x[0]-x[2]),(y[0]-y[2]))/(z[2]-z[0]);
   float pz = fabs(pt/tantheta)*((z[1]-z[0])>0. ? 1. : -1.);
 #ifdef INWARDFIT
   if (fiterrs) { // need conformal fit on seeds to be forward!
@@ -145,6 +147,6 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
   fitStateHit0.errors = ROOT::Math::Similarity(jacobian,fiterrors);
   */
 
-  fitStateHit0.charge = charge;//fixme, estimate from fit
+  fitStateHit0.charge = charge; //taken from slopes!
   //dumpMatrix(fitStateHit0.errors);
 }

--- a/ConformalUtils.cc
+++ b/ConformalUtils.cc
@@ -19,8 +19,8 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
   z[2]=hit2.position()[2];
 
   float u[3],v[3]; // conformal points
-  float initphi = abs(atan2(y[1],x[1])); // use this to decide when to use x -> u or x -> v
-  bool xtou = (initphi<Config::PIOver4 || initPhi>Config::PI3Over4);
+  float initphi = fabs(getPhi(x[1],y[1])); // use this to decide when to use x -> u or x -> v
+  bool xtou = (initphi<Config::PIOver4 || initphi>Config::PI3Over4);
 
   if (xtou){ // x -> u 
     for (unsigned int h=0;h<3;++h) {
@@ -65,7 +65,7 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
   float py  = fabs(pt*sin(phi))*((y[1]-y[0])>0. ? 1. : -1.);
 
   //compute theta
-  float tantheta = sqrtf(getRad2((x[0]-x[2]),(y[0]-y[2]))/(z[2]-z[0]);
+  float tantheta = sqrtf(getRad2((x[0]-x[2]),(y[0]-y[2])))/(z[2]-z[0]);
   float pz = fabs(pt/tantheta)*((z[1]-z[0])>0. ? 1. : -1.);
 #ifdef INWARDFIT
   if (fiterrs) { // need conformal fit on seeds to be forward!
@@ -120,7 +120,7 @@ void conformalFit(const Hit& hit0, const Hit& hit1, const Hit& hit2, int charge,
 
   fitStateHit0.errors[3][3] = pow(cos(phi),2)*pow(pterr,2)+pow(pt*sin(phi),2)*pow(phierr,2);
   fitStateHit0.errors[4][4] = pow(sin(phi),2)*pow(pterr,2)+pow(pt*cos(phi),2)*pow(phierr,2);
-  fitStateHit0.errors[5][5] = pow(1./tantheta,2)*pow(pterr,2)+pow(pt/pow(sin(atan(tantheta)),2),2)*pow(thetaerr,2);
+  fitStateHit0.errors[5][5] = pow(1./tantheta,2)*pow(pterr,2)+pow(pt/pow(tantheta/sqrtf(1.+pow(tantheta,2)),2),2)*pow(thetaerr,2);
 
   /*
   //fixme: if done with correlations pt pull gets larger, do I have a bug?  (actually scaling by 10k it looks nice as well)

--- a/ConformalUtils.h
+++ b/ConformalUtils.h
@@ -1,6 +1,7 @@
 #ifndef _conformalutils_
 #define _conformalutils_
 
+#include "Hit.h"
 #include "Track.h"
 #include "Matrix.h"
 

--- a/Hit.h
+++ b/Hit.h
@@ -198,8 +198,8 @@ public:
   SVector6&     error_nc()      {return state_.err_;}
 
   float r() const {
-    return std::sqrt(state_.parameters().At(0)*state_.parameters().At(0) +
-                     state_.parameters().At(1)*state_.parameters().At(1));
+    return sqrtf(state_.parameters().At(0)*state_.parameters().At(0) +
+		 state_.parameters().At(1)*state_.parameters().At(1));
   }
   float x() const {
     return state_.parameters().At(0);

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -98,13 +98,16 @@ void TTreeValidation::initializeDebugTree(){
   debugtree_->Branch("chi2",&chi2_debug_,"chi2[nlayers_debug_]/F");
 
   // MC
+  debugtree_->Branch("x_hit",&x_hit_debug_,"x_hit[nlayers_debug_]/F");
+  debugtree_->Branch("y_hit",&y_hit_debug_,"y_hit[nlayers_debug_]/F");
+  debugtree_->Branch("z_hit",&z_hit_debug_,"z_hit[nlayers_debug_]/F");
+  debugtree_->Branch("exx_hit",&exx_hit_debug_,"exx_hit[nlayers_debug_]/F");
+  debugtree_->Branch("eyy_hit",&eyy_hit_debug_,"eyy_hit[nlayers_debug_]/F");
+  debugtree_->Branch("ezz_hit",&ezz_hit_debug_,"ezz_hit[nlayers_debug_]/F");
+
   debugtree_->Branch("x_mc",&x_mc_debug_,"x_mc[nlayers_debug_]/F");
   debugtree_->Branch("y_mc",&y_mc_debug_,"y_mc[nlayers_debug_]/F");
   debugtree_->Branch("z_mc",&z_mc_debug_,"z_mc[nlayers_debug_]/F");
-  debugtree_->Branch("exx_mc",&exx_mc_debug_,"exx_mc[nlayers_debug_]/F");
-  debugtree_->Branch("eyy_mc",&eyy_mc_debug_,"eyy_mc[nlayers_debug_]/F");
-  debugtree_->Branch("ezz_mc",&ezz_mc_debug_,"ezz_mc[nlayers_debug_]/F");
-
   debugtree_->Branch("px_mc",&px_mc_debug_,"px_mc[nlayers_debug_]/F");
   debugtree_->Branch("py_mc",&py_mc_debug_,"py_mc[nlayers_debug_]/F");
   debugtree_->Branch("pz_mc",&pz_mc_debug_,"pz_mc[nlayers_debug_]/F");
@@ -199,6 +202,13 @@ void TTreeValidation::initializeDebugTree(){
   debugtree_->Branch("einvpt_up",&einvpt_up_debug_,"einvpt_up[nlayers_debug_]/F");
   debugtree_->Branch("theta_up",&theta_up_debug_,"theta_up[nlayers_debug_]/F");
   debugtree_->Branch("etheta_up",&etheta_up_debug_,"etheta_up[nlayers_debug_]/F");
+
+  debugtree_->Branch("etabin_hit",&ebhit_debug_,"etabin_hit[nlayers_debug_]/I");
+  debugtree_->Branch("etabinplus",&ebp_debug_,"etabinplus[nlayers_debug_]/I");
+  debugtree_->Branch("etabinminus",&ebm_debug_,"etabinminus[nlayers_debug_]/I");
+  debugtree_->Branch("phibin_hit",&pbhit_debug_,"phibin_hit[nlayers_debug_]/I");
+  debugtree_->Branch("phibinplus",&pbp_debug_,"phibinplus[nlayers_debug_]/I");
+  debugtree_->Branch("phibinminus",pbm_debug_,"phibinminus[nlayers_debug_]/I");
 }
 
 void TTreeValidation::initializeSeedInfoTree(){
@@ -768,8 +778,9 @@ void TTreeValidation::resetDebugTreeArrays(){
   for (int i = 0; i < Config::nLayers; i++){
     // reset MC info
     layer_mc_debug_[i]=-99;
+    x_hit_debug_[i]=-99;     y_hit_debug_[i]=-99;     z_hit_debug_[i]=-99; 
+    exx_hit_debug_[i]=-99;   eyy_hit_debug_[i]=-99;   ezz_hit_debug_[i]=-99;
     x_mc_debug_[i]=-99;     y_mc_debug_[i]=-99;     z_mc_debug_[i]=-99; 
-    exx_mc_debug_[i]=-99;   eyy_mc_debug_[i]=-99;   ezz_mc_debug_[i]=-99;
     px_mc_debug_[i]=-99;    py_mc_debug_[i]=-99;    pz_mc_debug_[i]=-99;
     pt_mc_debug_[i]=-99;    phi_mc_debug_[i]=-99;   eta_mc_debug_[i]=-99;
     invpt_mc_debug_[i]=-99; theta_mc_debug_[i]=-99;
@@ -799,6 +810,10 @@ void TTreeValidation::resetDebugTreeArrays(){
     ept_up_debug_[i]=-99;    ephi_up_debug_[i]=-99;   eeta_up_debug_[i]=-99;
     invpt_up_debug_[i] =-99; theta_up_debug_[i] =-99;
     einvpt_up_debug_[i]=-99; etheta_up_debug_[i]=-99;
+
+    // reset eta/phi bin info
+    ebhit_debug_[i] = -99; ebp_debug_[i] = -99; ebm_debug_[i] = -99;
+    pbhit_debug_[i] = -99; pbp_debug_[i] = -99; pbm_debug_[i] = -99;
   }
 }
 
@@ -832,14 +847,21 @@ void TTreeValidation::fillDebugTree(const Event& ev){
   for (int i = 0; i < simhits.size(); i++){ // assume one hit for layer for sim tracks...
     layer_mc_debug_[i] = i;
 
-    x_mc_debug_[i] = simhits[i].x();
-    y_mc_debug_[i] = simhits[i].y();
-    z_mc_debug_[i] = simhits[i].z();
-    exx_mc_debug_[i] = simhits[i].exx();
-    eyy_mc_debug_[i] = simhits[i].eyy();
-    ezz_mc_debug_[i] = simhits[i].ezz();
+    x_hit_debug_[i]   = simhits[i].x();
+    y_hit_debug_[i]   = simhits[i].y();
+    z_hit_debug_[i]   = simhits[i].z();
+    exx_hit_debug_[i] = simhits[i].exx();
+    eyy_hit_debug_[i] = simhits[i].eyy();
+    ezz_hit_debug_[i] = simhits[i].ezz();
+
+    // which eta/phi bin the hit belongs to
+    ebhit_debug_[i] = getEtaPartition(simhits[i].eta());
+    pbhit_debug_[i] = getPhiPartition(simhits[i].phi());
 
     const TrackState & mcstate = simTkTSVecMap_[mcID][i];
+    x_mc_debug_[i]   = mcstate.x();
+    y_mc_debug_[i]   = mcstate.y();
+    z_mc_debug_[i]   = mcstate.z();
     pt_mc_debug_[i]  = mcstate.pT();
     phi_mc_debug_[i] = mcstate.momPhi();
     eta_mc_debug_[i] = mcstate.momEta();
@@ -951,6 +973,24 @@ void TTreeValidation::fillDebugTree(const Event& ev){
     einvpt_up_debug_[layer] = upTS.einvpT();
     theta_up_debug_[layer]  = upTS.theta();
     etheta_up_debug_[layer] = upTS.etheta();
+  }
+
+  // see what it predicted! (reuse branchval)
+  for (TkIDToBVVMMIter seediter = seedToBranchValVecLayMapMap_.begin(); seediter != seedToBranchValVecLayMapMap_.end(); ++seediter){
+    for (BVVLMiter layiter = (*seediter).second.begin(); layiter != (*seediter).second.end(); ++layiter){
+      const auto& BranchValVec((*layiter).second);
+      const int cands = BranchValVec.size();
+      int layer = (*layiter).first; // first index here is layer
+      for (int cand = 0; cand < cands; cand++){ // loop over input candidates at this layer for this seed
+	const auto& BranchVal(BranchValVec[cand]); // grab the branch validation object
+	
+	ebp_debug_[layer]  = BranchVal.etaBinPlus;
+	ebm_debug_[layer]  = BranchVal.etaBinMinus;
+	pbp_debug_[layer]  = BranchVal.phiBinPlus;
+	pbm_debug_[layer]  = BranchVal.phiBinMinus;
+
+      }
+    }
   }
 
   // fill it once per track (i.e. once per track by definition)

--- a/TTreeValidation.h
+++ b/TTreeValidation.h
@@ -133,8 +133,9 @@ public:
   // mc truth
   int mccharge_debug_;
   int layer_mc_debug_[Config::nLayers];
+  float x_hit_debug_[Config::nLayers],y_hit_debug_[Config::nLayers],z_hit_debug_[Config::nLayers];
+  float exx_hit_debug_[Config::nLayers],eyy_hit_debug_[Config::nLayers],ezz_hit_debug_[Config::nLayers];
   float x_mc_debug_[Config::nLayers],y_mc_debug_[Config::nLayers],z_mc_debug_[Config::nLayers];
-  float exx_mc_debug_[Config::nLayers],eyy_mc_debug_[Config::nLayers],ezz_mc_debug_[Config::nLayers];
   float px_mc_debug_[Config::nLayers],py_mc_debug_[Config::nLayers],pz_mc_debug_[Config::nLayers];
   float pt_mc_debug_[Config::nLayers],phi_mc_debug_[Config::nLayers],eta_mc_debug_[Config::nLayers];
   float invpt_mc_debug_[Config::nLayers],theta_mc_debug_[Config::nLayers];
@@ -173,7 +174,11 @@ public:
   float ept_up_debug_[Config::nLayers],ephi_up_debug_[Config::nLayers],eeta_up_debug_[Config::nLayers];
   float invpt_up_debug_[Config::nLayers],theta_up_debug_[Config::nLayers];
   float einvpt_up_debug_[Config::nLayers],etheta_up_debug_[Config::nLayers];
-  
+
+  // eta/phi bin info
+  int ebhit_debug_[Config::nLayers], ebp_debug_[Config::nLayers], ebm_debug_[Config::nLayers];
+  int pbhit_debug_[Config::nLayers], pbp_debug_[Config::nLayers], pbm_debug_[Config::nLayers];
+
   // seedinfo tree
   TTree* seedinfotree_;
   int evtID_seedinfo_;

--- a/main.cc
+++ b/main.cc
@@ -188,12 +188,6 @@ int main(int argc, const char* argv[])
   tbb::task_scheduler_init tasks(nThread);
 #endif
 
-  if (Config::super_debug){
-    Config::nEvents = 100000;
-    Config::nTracks = 1;
-  }
-
-
   for (int evt=0; evt<Config::nEvents; ++evt) {
     Event ev(geom, val, evt, nThread);
     std::cout << "EVENT #"<< ev.evtID() << std::endl;

--- a/mkFit/ConformalUtilsMPlex.cc
+++ b/mkFit/ConformalUtilsMPlex.cc
@@ -1,0 +1,223 @@
+#include "ConformalUtilsMPlex.h"
+
+inline
+void CFMap(const MPlexHH& A, const MPlexHV& B, MPlexHV& C)
+{
+  using idx_t = Matriplex::idx_t;
+
+  // C = A * B, C is 3x1, A is 3x3 , B is 3x1
+
+  typedef float T;
+  typedef float Tv;
+  const idx_t N = NN;
+
+  const T *a = A.fArray; ASSUME_ALIGNED(a, 64);
+  const Tv *b = B.fArray; ASSUME_ALIGNED(b, 64);
+  Tv *c = C.fArray; ASSUME_ALIGNED(c, 64);
+
+#include "CFMatrix33Vector3.ah"
+}
+
+//M. Hansroul, H. Jeremie and D. Savard, NIM A 270 (1988) 498
+//http://www.sciencedirect.com/science/article/pii/016890028890722X
+
+void conformalFitMPlex(bool fitting, const MPlexQI inChg, 
+		       MPlexLS& outErr, MPlexLV& outPar, 
+		       const MPlexHV& msPar0, const MPlexHV& msPar1, const MPlexHV& msPar2)
+{
+  using idx_t = Matriplex::idx_t;
+  const idx_t N = NN;
+
+  // Store positions in mplex vectors... could consider storing in a 3x3 matrix, too
+  MPlexHV x, y, z, r2;
+#pragma simd
+  for (int n = 0; n < N; ++n) 
+  {
+    x.At(n, 0, 0) = msPar0.ConstAt(n, 0, 0);
+    x.At(n, 1, 0) = msPar1.ConstAt(n, 0, 0);
+    x.At(n, 2, 0) = msPar2.ConstAt(n, 0, 0);
+
+    y.At(n, 0, 0) = msPar0.ConstAt(n, 1, 0);
+    y.At(n, 1, 0) = msPar1.ConstAt(n, 1, 0);
+    y.At(n, 2, 0) = msPar2.ConstAt(n, 1, 0);
+
+    z.At(n, 0, 0) = msPar0.ConstAt(n, 2, 0);
+    z.At(n, 1, 0) = msPar1.ConstAt(n, 2, 0);
+    z.At(n, 2, 0) = msPar2.ConstAt(n, 2, 0);
+    
+    for (int i = 0; i < 3; ++i)
+    {
+      r2.At(n, i, 0) = getRad2(x.ConstAt(n, i, 0), y.ConstAt(n, i, 0));
+    }
+  }
+  
+  MPlexQF initPhi;
+  MPlexQI xtou; // bool to determine "split space", i.e. map x to u or v
+#pragma simd
+  for (int n = 0; n < N; ++n) 
+  {
+    initPhi.At(n, 0, 0) = fabs(getPhi(x.ConstAt(n, 0, 0), y.ConstAt(n, 0, 0)));
+    xtou.At(n, 0, 0)    = ((initPhi.ConstAt(n, 0, 0) < Config::PIOver4 || initPhi.ConstAt(n, 0, 0) > Config::PI3Over4) ? 1 : 0);
+  }
+
+  MPlexHV u,v;
+#pragma simd
+  for (int n = 0; n < N; ++n) 
+  {
+    if (xtou.At(n, 0, 0)) // x mapped to u
+    {
+      for (int i = 0; i < 3; ++i) 
+      {
+	u.At(n, i, 0) = x.ConstAt(n, i, 0) / r2.ConstAt(n, i, 0);
+	v.At(n, i, 0) = y.ConstAt(n, i, 0) / r2.ConstAt(n, i, 0);
+      }
+    }
+    else // x mapped to v
+    {
+      for (int i = 0; i < 3; ++i) 
+      {
+	u.At(n, i, 0) = y.ConstAt(n, i, 0) / r2.ConstAt(n, i, 0);
+	v.At(n, i, 0) = x.ConstAt(n, i, 0) / r2.ConstAt(n, i, 0);
+      }
+    }
+  }
+
+  MPlexHH A;
+  MPlexHV B;
+#pragma simd
+  for (int n = 0; n < N; ++n) 
+  {
+    for (int i = 0; i < 3; ++i) 
+    {
+      A.At(n, i, 0) = 1.;
+      A.At(n, i, 1) = -u.ConstAt(n, i, 0);
+      A.At(n, i, 2) = -u.ConstAt(n, i, 0)*u.ConstAt(n, i, 0);
+      B.At(n, i, 0) = v.ConstAt(n, i, 0);
+    }
+  }
+  Matriplex::InvertCramer(A);  
+  MPlexHV C; 
+  CFMap(A, B, C);
+  
+  MPlexQF a,b;
+#pragma simd
+  for (int n = 0; n < N; ++n) 
+  {
+    b.At(n, 0, 0) = 1./(2.*C.ConstAt(n, 0, 0)); 
+    a.At(n, 0, 0) = b.ConstAt(n, 0, 0)*C.ConstAt(n, 1, 0); 
+  }  
+
+  // do i really need all these temp mplexs????
+  MPlexQF vrx, vry, phi, pT, pT2, px, py, pz, pz2;
+  //#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    vrx.At(n, 0, 0) = (xtou.ConstAt(n, 0, 0) ? x.ConstAt(n, 0, 0) - a.ConstAt(n, 0, 0) : x.ConstAt(n, 0, 0) - b.ConstAt(n, 0, 0));
+    vry.At(n, 0, 0) = (xtou.ConstAt(n, 0, 0) ? y.ConstAt(n, 0, 0) - b.ConstAt(n, 0, 0) : y.ConstAt(n, 0, 0) - a.ConstAt(n, 0, 0));
+    phi.At(n, 0, 0) = atan2(vrx.ConstAt(n, 0, 0),vry.ConstAt(n, 0, 0));
+    pT.At (n, 0, 0) = (-Config::sol*Config::Bfield)*hipo(vrx.ConstAt(n, 0, 0), vry.ConstAt(n, 0, 0)) / (inChg.ConstAt(n, 0, 0) * 100);
+    px.At (n, 0, 0) = fabs(pT.ConstAt(n, 0, 0) * cos(phi.ConstAt(n, 0, 0))) * ((x.ConstAt(n, 1, 0) - x.ConstAt(n, 0, 0))>0. ? 1. : -1.);
+    py.At (n, 0, 0) = fabs(pT.ConstAt(n, 0, 0) * sin(phi.ConstAt(n, 0, 0))) * ((y.ConstAt(n, 1, 0) - y.ConstAt(n, 0, 0))>0. ? 1. : -1.);
+    pz.At (n, 0, 0) = fabs((pT.ConstAt(n, 0, 0) * (z.ConstAt(n, 2, 0) - z.ConstAt(n, 0, 0))) / hipo((x.ConstAt(n, 2, 0) - x.ConstAt(n, 0, 0)), (y.ConstAt(n, 2, 0) - y.ConstAt(n, 0, 0)))) * ((z.ConstAt(n, 1, 0) - z.ConstAt(n, 0, 0)) > 0. ? 1. : -1.);
+
+    pT2.At(n, 0, 0) = pT.ConstAt(n, 0, 0)*pT.ConstAt(n, 0, 0);
+    pz2.At(n, 0, 0) = pz.ConstAt(n, 0, 0)*pz.ConstAt(n, 0, 0);
+  }
+
+#ifdef INWARDFIT
+  if (fitting)
+  {
+#pragma simd
+    for (int n = 0; n < N; ++n)
+    {
+      px.At(n, 0, 0) *= -1.;
+      py.At(n, 0, 0) *= -1.;
+      pz.At(n, 0, 0) *= -1.;
+    }
+  }
+#endif
+ 
+ //  Start setting the output parameters
+#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    outPar.At(n, 0, 0) = x.ConstAt(n, 0, 0);
+    outPar.At(n, 1, 0) = y.ConstAt(n, 0, 0);
+    outPar.At(n, 2, 0) = z.ConstAt(n, 0, 0);
+    outPar.At(n, 3, 0) = px.ConstAt(n, 0, 0);
+    outPar.At(n, 4, 0) = py.ConstAt(n, 0, 0);
+    outPar.At(n, 5, 0) = pz.ConstAt(n, 0, 0);
+  }
+
+  // Use r-phi smearing to set initial error estimation
+  // uncertainties set by hand by making pulls width of 1.0 (extracted from residuals)
+  float ptinverr, phierr, thetaerr;
+  if (fitting)
+  {
+    ptinverr = Config::ptinverr049;
+    phierr   = Config::phierr049;
+    thetaerr = Config::thetaerr049;
+  }
+  else
+  {
+    ptinverr = Config::ptinverr012;
+    phierr   = Config::phierr012;
+    thetaerr = Config::thetaerr012;
+  }
+
+  MPlexQF varPt, varPhi, invvarR2, varTheta;
+#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    varPt.At   (n, 0, 0) = pT2.ConstAt(n, 0, 0)*ptinverr*ptinverr;
+    varPhi.At  (n, 0, 0) = Config::varXY/r2.ConstAt(n, 0, 0);
+    invvarR2.At(n, 0, 0) = Config::varR/r2.ConstAt(n, 0, 0);
+    varTheta.At(n, 0, 0) = ((pT2.ConstAt(n, 0, 0) + pz2.ConstAt(n, 0, 0))*(pT2.ConstAt(n, 0, 0) + pz2.ConstAt(n, 0, 0))) / pT2.ConstAt(n, 0, 0) * thetaerr * thetaerr;
+  }
+
+#pragma simd
+  for (int n = 0; n < N; ++n)
+  {
+    outErr.At(n, 0, 0) = x.ConstAt(n, 0, 0)*x.ConstAt(n, 0, 0)*invvarR2.ConstAt(n, 0, 0) + y.ConstAt(n, 0, 0)*y.ConstAt(n, 0, 0)*varPhi.ConstAt(n, 0, 0);
+    outErr.At(n, 0, 1) = x.ConstAt(n, 0, 0)*y.ConstAt(n, 0, 0)*(invvarR2.ConstAt(n, 0, 0) - varPhi.ConstAt(n, 0, 0));
+    outErr.At(n, 0, 2) = 0.;
+    outErr.At(n, 0, 3) = 0.;
+    outErr.At(n, 0, 4) = 0.;
+    outErr.At(n, 0, 5) = 0.;
+
+    outErr.At(n, 1, 0) = outErr.ConstAt(n, 0, 1);
+    outErr.At(n, 1, 1) = y.ConstAt(n, 0, 0)*y.ConstAt(n, 0, 0)*invvarR2.ConstAt(n, 0, 0) + x.ConstAt(n, 0, 0)*x.ConstAt(n, 0, 0)*varPhi.ConstAt(n, 0, 0);
+    outErr.At(n, 1, 2) = 0.;
+    outErr.At(n, 1, 3) = 0.;
+    outErr.At(n, 1, 4) = 0.;
+    outErr.At(n, 1, 5) = 0.;
+
+    outErr.At(n, 2, 0) = 0.;
+    outErr.At(n, 2, 1) = 0.;
+    outErr.At(n, 2, 2) = Config::varZ;
+    outErr.At(n, 2, 3) = 0.;
+    outErr.At(n, 2, 4) = 0.;
+    outErr.At(n, 2, 5) = 0.;
+
+    outErr.At(n, 3, 0) = 0.;
+    outErr.At(n, 3, 1) = 0.;
+    outErr.At(n, 3, 2) = 0.;
+    outErr.At(n, 3, 3) = px.ConstAt(n, 0, 0)*px.ConstAt(n, 0, 0)*varPt(n, 0, 0) + py.ConstAt(n, 0, 0)*py.ConstAt(n, 0, 0)*phierr*phierr;
+    outErr.At(n, 3, 4) = 0.;
+    outErr.At(n, 3, 5) = 0.;
+
+    outErr.At(n, 4, 0) = 0.;
+    outErr.At(n, 4, 1) = 0.;
+    outErr.At(n, 4, 2) = 0.;
+    outErr.At(n, 4, 3) = 0.;
+    outErr.At(n, 4, 4) = py.ConstAt(n, 0, 0)*py.ConstAt(n, 0, 0)*varPt(n, 0, 0) + px.ConstAt(n, 0, 0)*px.ConstAt(n, 0, 0)*phierr*phierr;
+    outErr.At(n, 4, 5) = 0.;
+
+    outErr.At(n, 5, 0) = 0.;
+    outErr.At(n, 5, 1) = 0.;
+    outErr.At(n, 5, 2) = 0.;
+    outErr.At(n, 5, 3) = 0.;
+    outErr.At(n, 5, 4) = 0.;
+    outErr.At(n, 5, 5) = pz2.ConstAt(n, 0, 0)*varPt.ConstAt(n, 0, 0) + varTheta.ConstAt(n, 0, 0);
+  }  
+}

--- a/mkFit/ConformalUtilsMPlex.h
+++ b/mkFit/ConformalUtilsMPlex.h
@@ -1,0 +1,13 @@
+#ifndef _conformalutils_mplex_
+#define _conformalutils_mplex_
+
+#include "Hit.h"
+#include "Track.h"
+#include "Matrix.h"
+
+  // write to iC --> next step will be a propagation no matter what
+void conformalFitMPlex(bool fitting, const MPlexQI inChg, 
+		       MPlexLS& outErr, MPlexLV& outPar, 
+		       const MPlexHV& msPar0, const MPlexHV& msPar1, const MPlexHV& msPar2);
+
+#endif

--- a/mkFit/GenMPlexOps.pl
+++ b/mkFit/GenMPlexOps.pl
@@ -6,6 +6,20 @@ use GenMul;
 use warnings;
 
 #------------------------------------------------------------------------------
+### simple general 3x3 matrix times 3 vector multiplication for CF MPlex
+
+$A = new GenMul::Matrix('name'=>'a', 'M'=>3, 'N'=>3);
+
+$B = new GenMul::Matrix('name'=>'b', 'M'=>3, 'N'=>1);
+
+$C = new GenMul::Matrix('name'=>'c', 'M'=>3, 'N'=>1);
+
+$m = new GenMul::Multiply;
+
+$m->dump_multiply_std_and_intrinsic("CFMatrix33Vector3.ah",
+                                    $A, $B, $C);
+
+#------------------------------------------------------------------------------
 ###updateParametersMPlex -- propagated errors in "polar" coordinates
 # propErr_pol = jac_pol * propErr * jac_polT
 

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -109,6 +109,7 @@ inline void MkBuilder::fit_one_seed(TrackVec& simtracks, int itrack, int end, Mk
 {
   mkfp->SetNhits(3);//just to be sure (is this needed?)
   mkfp->InputTracksAndHits(simtracks, m_event->layerHits_, itrack, end);
+  if (Config::cf_seeding) mkfp->ConformalFitTracks(false, itrack, end);
   if (Config::readCmsswSeeds==false) mkfp->FitTracks();
 
   const int ilay = 3; // layer 4

--- a/mkFit/MkFitter.h
+++ b/mkFit/MkFitter.h
@@ -68,6 +68,7 @@ public:
                             int beg, int end, bool inputProp);
   void InputTracksOnly   (std::vector<Track>& tracks, int beg, int end);
   void InputHitsOnly(std::vector<Hit>& hits, int beg, int end);
+  void ConformalFitTracks(bool fitting, int beg, int end);
   void FitTracks();
 
   void OutputTracks(std::vector<Track>& tracks, int beg, int end, int iCP);

--- a/mkFit/fittestMPlex.cc
+++ b/mkFit/fittestMPlex.cc
@@ -139,7 +139,7 @@ double runFittingTestPlex(Event& ev, std::vector<Track>& rectracks)
       MkFitter *mkfp = mkfp_arr[omp_get_thread_num()];
 
       mkfp->InputTracksAndHits(simtracks, ev.layerHits_, itrack, end);
-
+      if (Config::cf_fitting) mkfp->ConformalFitTracks(true, itrack, end);
       mkfp->FitTracks();
 
 #ifndef NO_ROOT

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -1,4 +1,4 @@
-#include "Matriplex/MatriplexCommon.h"
+A1;2c#include "Matriplex/MatriplexCommon.h"
 
 #include "fittestMPlex.h"
 #include "buildtestMPlex.h"
@@ -12,6 +12,10 @@
 #include <limits>
 
 #include "Event.h"
+
+#ifndef NO_ROOT
+#include "TTreeValidation.h"
+#endif
 
 #ifdef USE_CUDA
 #include "FitterCU.h"
@@ -155,8 +159,12 @@ void test_standard()
 
   Geometry geom;
   initGeom(geom);
+#ifdef NO_ROOT
   Validation val;
-
+#else 
+  TTreeValidation val("valtree.root");
+#endif
+  
   const int NT = 5;
   double t_sum[NT] = {0};
   double t_skip[NT] = {0};
@@ -316,6 +324,10 @@ void test_standard()
 
     for (int i = 0; i < NT; ++i) t_sum[i] += t_cur[i];
     if (evt > 1) for (int i = 0; i < NT; ++i) t_skip[i] += t_cur[i];
+
+#ifndef NO_ROOT
+    make_validation_tree("validation-plex.root", ev.simTracks_, plex_tracks);
+#endif
   }
 #endif
   printf("\n");
@@ -332,10 +344,6 @@ void test_standard()
   {
     close_simtrack_file();
   }
-
-#ifndef NO_ROOT
-  make_validation_tree("validation-plex.root", ev.simTracks_, plex_tracks);
-#endif
 }
 
 //==============================================================================

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -1,4 +1,4 @@
-A1;2c#include "Matriplex/MatriplexCommon.h"
+#include "Matriplex/MatriplexCommon.h"
 
 #include "fittestMPlex.h"
 #include "buildtestMPlex.h"
@@ -409,6 +409,8 @@ int main(int argc, const char *argv[])
         "  --best-out-of   <num>    run track finding num times, report best time (def: %d)\n"
 	"  --cms-geom               use cms-like geometry (def: %i)\n"
 	"  --cmssw-seeds            take seeds from CMSSW (def: %i)\n"
+	"  --cf-seeding             enable CF in seeding (def: %s)\n"
+	"  --cf-fitting             enable CF in fitting (def: %s)\n"
 	"  --write                  write simulation to file and exit\n"
 	"  --read                   read simulation from file\n"
 	"  --file-name              file name for write/read (def: %s)\n"
@@ -425,6 +427,8 @@ int main(int argc, const char *argv[])
         Config::finderReportBestOutOfN,
 	Config::useCMSGeom,
 	Config::readCmsswSeeds,
+	Config::cf_seeding ? "true" : "false",
+	Config::cf_fitting ? "true" : "false",
 	g_file_name.c_str()
       );
       exit(0);
@@ -495,6 +499,14 @@ int main(int argc, const char *argv[])
     else if(*i == "--cmssw-seeds")
     {
       Config::readCmsswSeeds = true;
+    }
+    else if (*i == "--cf-seeding")
+    {
+      Config::cf_seeding = true;
+    }
+    else if (*i == "--cf-fitting")
+    {
+      Config::cf_fitting = true;
     }
     else if (*i == "--num-thr-ev")
     {


### PR DESCRIPTION
This PR differs from the last in that I got rid of the redundancy of vector B in the CF MPlex port, as well as moved the three position vectors into a 3x3 matrix.  

The results from the benchmarking are here: https://kmcdermo.web.cern.ch/kmcdermo/after2/

They should be compared with /after/ from the previous PR.  The nHits went up by 0.002 across the board... not sure why. 

---------------

I ran a "BH" version of the SMatrix with 10 events with 20k tracks, and the results are comparable to what is seen in Matriplex in terms of the degradation expected from using CF as the initial state for building vs. MC truth in the BH scenario.

Below are the number of hits/track for a given test
For Matriplex (from /before/ and /after/):
MC Full Building: 9.853
CF Full Building: 9.718

MC BH Building: 9.578
CF BH Building: 9.078

For SMatrix (local tests):
MC Full Building: 9.993
CF Full Building: 9.846

MC BH Building: 9.674
CF BH Building: 9.126

So the SMatrix does overall 0.1 hits/track better than Matriplex, but this is expected, as SMatrix does not have strict thread boundaries.