### PR TITLE
Convert best hit builder to TBB

### DIFF
--- a/Math/MatrixRepresentationsStatic.h
+++ b/Math/MatrixRepresentationsStatic.h
@@ -252,6 +252,7 @@ namespace Math {
          return *this;
       }
       inline MatRepSym<T, D>& operator=(const MatRepSym& rhs) {
+         #pragma ivdep
          for(unsigned int i=0; i<kSize; ++i) fArray[i] = rhs.Array()[i];
          return *this;
       }

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -23,6 +23,7 @@ for nth in 10 12 14 16
 do
 echo nth=${nth}
 ./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-tbb --num-thr ${nth} --cloner-single-thread >& log_host_10x20k_TBBST_NVU8int_NTH${nth}.txt
+./mkFit/mkFit --read --file-name ${dir}/simtracks_10x20k.bin --build-bh  --num-thr ${nth} >& log_host_10x20k_BH_NVU8int_NTH${nth}.txt
 done
 
 sed -i 's/# USE_INTRINSICS := -DMPT_SIZE=1/USE_INTRINSICS := -DMPT_SIZE=XX/g' Makefile.config

--- a/makeBenchmarkPlots.C
+++ b/makeBenchmarkPlots.C
@@ -126,7 +126,7 @@ void makeBenchmarkPlots()
   g_BH_TH->GetYaxis()->SetTitle("Time for 10 events x 20k tracks [s]");
   g_BH_TH->GetXaxis()->SetRangeUser(1,maxth);
   g_BH_TH->GetYaxis()->SetRangeUser(0,10);
-  if (isMic) g_BH_TH->GetYaxis()->SetRangeUser(0.2,100);
+  if (isMic) g_BH_TH->GetYaxis()->SetRangeUser(0.1,100);
   g_BH_TH->SetLineWidth(2);
   g_CE_TH->SetLineWidth(2);
   g_CEST_TH->SetLineWidth(2);

--- a/makeBenchmarkPlots.py
+++ b/makeBenchmarkPlots.py
@@ -77,7 +77,7 @@ for test in ['BH','CE','CEST','ST','TBBST','FIT']:
     nvu = '8int'
     if hORm == 'mic': nvu = '16int'
     thvals = [1,3,7,21]
-    if 'TBB' in test : thvals = [1,3,7,10,12,14,16,21]
+    if 'TBB' in test or 'BH' in test : thvals = [1,3,7,10,12,14,16,21]
     if hORm == 'mic': thvals = [1,3,7,21,42,63,84,105,126,147,168,189,210]
     g_TH = ROOT.TGraph(len(thvals))
     g_TH_speedup = ROOT.TGraph(len(thvals))

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -173,64 +173,6 @@ void MkBuilder::begin_event(Event* ev, EventTmp* ev_tmp, const char* build_type)
   if (Config::readCmsswSeeds==false) m_event->seedTracks_.resize(simtracks.size());
 }
 
-#ifdef DEBUG
-namespace {
-  void pre_prop_print(int ilay, const MkFitter* mkfp) {
-    std::cout << "propagate to lay=" << ilay+1 
-              << " start from x=" << mkfp->getPar(0, 0, 0) << " y=" << mkfp->getPar(0, 0, 1) << " z=" << mkfp->getPar(0, 0, 2)
-              << " r=" << getHypot(mkfp->getPar(0, 0, 0), mkfp->getPar(0, 0, 1))
-              << " px=" << mkfp->getPar(0, 0, 3) << " py=" << mkfp->getPar(0, 0, 4) << " pz=" << mkfp->getPar(0, 0, 5)
-              << " pT=" << getHypot(mkfp->getPar(0, 0, 3), mkfp->getPar(0, 0, 4)) << std::endl;
-  }
-
-  void post_prop_print(int ilay, const MkFitter* mkfp) {
-    std::cout << "propagate to lay=" << ilay+1 
-              << " arrive at x=" << mkfp->getPar(0, 1, 0) << " y=" << mkfp->getPar(0, 1, 1) << " z=" << mkfp->getPar(0, 1, 2)
-              << " r=" << getHypot(mkfp->getPar(0, 1, 0), mkfp->getPar(0, 1, 1)) << std::endl;
-  }
-
-  void print_seed(const Track& seed) {
-    std::cout << "MX - found seed with nHits=" << seed.nFoundHits() << " chi2=" << seed.chi2()
-              << " posEta=" << seed.posEta() << " posPhi=" << seed.posPhi() << " posR=" << seed.posR()
-              << " pT=" << seed.pT() << std::endl;
-  }
-
-  void print_seed2(const Track& seed) {
-    std::cout << "MX - found seed with nFoundHits=" << seed.nFoundHits() << " chi2=" << seed.chi2() 
-              << " x=" << seed.x() << " y=" << seed.y() << " z=" << seed.z()
-              << " px=" << seed.px() << " py=" << seed.py() << " pz=" << seed.pz()
-              << " pT=" << seed.pT() << std::endl;
-  }
-
-  void print_seeds(const TrackVec& seeds) {
-    std::cout << "found total seeds=" << seeds.size() << std::endl;
-    for (auto&& seed : seeds) {
-      print_seed(seed);
-    }
-  }
-
-  void print_seeds(const EventOfCandidates& event_of_cands) {
-    for (int ebin = 0; ebin < Config::nEtaBin; ++ebin) {
-      const EtaBinOfCandidates &etabin_of_candidates = event_of_cands.m_etabins_of_candidates[ebin]; 
-      for (int iseed = 0; iseed < etabin_of_candidates.m_fill_index; iseed++) {
-        print_seed2(etabin_of_candidates.m_candidates[iseed]);
-      }
-    }
-  }
-
-  void print_seeds(const EventOfCombCandidates& event_of_comb_cands) {
-    for (int ebin = 0; ebin < Config::nEtaBin; ++ebin) {
-      const EtaBinOfCombCandidates &etabin_of_comb_candidates = event_of_comb_cands.m_etabins_of_comb_candidates[ebin]; 
-      for (int iseed = 0; iseed < etabin_of_comb_candidates.m_fill_index; iseed++) {
-        print_seed2(etabin_of_comb_candidates.m_candidates[iseed].front());
-      }
-    }
-  }
-
-  bool debug = true;
-}
-#endif
-
 inline void MkBuilder::fit_one_seed_set(TrackVec& simtracks, int itrack, int end, MkFitter *mkfp)
 {
   mkfp->SetNhits(3); //just to be sure (is this needed?)
@@ -387,17 +329,6 @@ void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
 
           } // end of layer loop
           mkfp->OutputFittedTracksAndHitIdx(etabin_of_candidates.m_candidates, itrack, end, true);
-
-          //propagate to layer
-          // This is sort of a silly fix as no-clone-engine code produces
-          // zero good tracks with propagate-at-the-end.
-          // But at least it doesn't crash with uncaught exception :)
-          if (ilay + 1 < Config::nLayers)
-          {
-            dcall(pre_prop_print(ilay, mkfp));
-            mkfp->PropagateTracksToR(m_event->geom_.Radius(ilay+1), end - itrack);
-            dcall(post_prop_print(ilay, mkfp));
-          }
         }
       }); // end of seed loop
     }

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -277,8 +277,6 @@ void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
   //dump seeds
   dcall(print_seeds(event_of_cands));
 
-  assert(Config::numSeedsPerTask % NN == 0);
-
   tbb::parallel_for(tbb::blocked_range<int>(0, Config::nEtaBin),
     [&](const tbb::blocked_range<int>& ebins)
   {
@@ -288,11 +286,12 @@ void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
       tbb::parallel_for(tbb::blocked_range<int>(0,etabin_of_candidates.m_fill_index,Config::numSeedsPerTask), 
         [&](const tbb::blocked_range<int>& tracks)
       {
+        std::unique_ptr<MkFitter, decltype(retfitr)> mkfp(g_exe_ctx.m_fitters.GetFromPool(), retfitr);
+
         for (int itrack = tracks.begin(); itrack < tracks.end(); itrack += NN) {
-          int end = std::min(itrack + NN, etabin_of_candidates.m_fill_index);
+          int end = std::min(itrack + NN, tracks.end());
 
           dprint(std::endl << "processing track=" << itrack << " etabin=" << ebin << " findex=" << etabin_of_candidates.m_fill_index);
-          std::unique_ptr<MkFitter, decltype(retfitr)> mkfp(g_exe_ctx.m_fitters.GetFromPool(), retfitr);
 
           mkfp->SetNhits(3);//just to be sure (is this needed?)
           mkfp->InputTracksAndHitIdx(etabin_of_candidates.m_candidates, itrack, end, true);

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -258,7 +258,7 @@ void MkBuilder::quality_print()
 // FindTracksBestHit
 //------------------------------------------------------------------------------
 
-void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
+void MkBuilder::find_tracks_load_seeds(EventOfCandidates& event_of_cands)
 {
   // partition recseeds into eta bins
   for (int iseed = 0; iseed < m_event->seedTracks_.size(); ++iseed)
@@ -273,7 +273,10 @@ void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
 
   //dump seeds
   dcall(print_seeds(event_of_cands));
+}
 
+void MkBuilder::FindTracksBestHit(EventOfCandidates& event_of_cands)
+{
   tbb::parallel_for(tbb::blocked_range<int>(0, Config::nEtaBin),
     [&](const tbb::blocked_range<int>& ebins)
   {

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -125,6 +125,7 @@ public:
 
   // Common foos for FindTracks() / FindTracksCloneEngine() ???
 
+  void find_tracks_load_seeds(EventOfCandidates& event_of_cands); // for FindTracksBestHit
   void find_tracks_load_seeds();
   void find_tracks_in_layers(EtaBinOfCombCandidates &eb_of_cc, CandCloner &cloner, MkFitter *mkfp,
                              int start_seed, int end_seed, int ebin);

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -90,7 +90,7 @@ class MkFitter;
 class MkBuilder
 {
 private:
-  void fit_one_seed(TrackVec& simtracks, int itrack, int end, MkFitter *mkfp);
+  void fit_one_seed_set(TrackVec& simtracks, int itrack, int end, MkFitter *mkfp);
 
   Event         *m_event;
   EventTmp      *m_event_tmp;

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -78,6 +78,7 @@ double runBuildingTestPlexBestHit(Event& ev)
   builder.fit_seeds_tbb();
 
   EventOfCandidates event_of_cands;
+  builder.find_tracks_load_seeds(event_of_cands);
 
 #ifdef USE_VTUNE_PAUSE
   __itt_resume();

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -75,7 +75,7 @@ double runBuildingTestPlexBestHit(Event& ev)
 
   builder.begin_event(&ev, 0, __func__);
 
-  builder.fit_seeds();
+  builder.fit_seeds_tbb();
 
   EventOfCandidates event_of_cands;
 

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -254,6 +254,14 @@ void test_standard()
   std::cerr << "###### Total GPU time: " << dtime() - total_gpu_time << " ######\n";
 
 #else
+  // MT: task_scheduler_init::automatic doesn't really work (segv!) + we don't
+  // know what to do for non-tbb cases.
+  // tbb::task_scheduler_init tbb_init(Config::numThreadsFinder != 0 ?
+  //                                   Config::numThreadsFinder :
+  //                                   tbb::task_scheduler_init::automatic);
+  tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
+  omp_set_num_threads(Config::numThreadsFinder);
+
   for (int evt = 1; evt <= Config::nEvents; ++evt)
   {
     printf("\n");
@@ -269,18 +277,11 @@ void test_standard()
     else
     {
       //Simulate() parallelism is via TBB
-      tbb::task_scheduler_init tbb_init(Config::numThreadsSimulation);
+      //tbb::task_scheduler_init tbb_init(Config::numThreadsSimulation);
+
       ev.Simulate();
       ev.resetLayerHitMap(true);
     }
-
-    // MT: task_scheduler_init::automatic doesn't really work (segv!) + we don't
-    // know what to do for non-tbb cases.
-    // tbb::task_scheduler_init tbb_init(Config::numThreadsFinder != 0 ?
-    //                                   Config::numThreadsFinder :
-    //                                   tbb::task_scheduler_init::automatic);
-    tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
-    omp_set_num_threads(Config::numThreadsFinder);
 
     plex_tracks.resize(ev.simTracks_.size());
 

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -276,7 +276,8 @@ void test_standard()
     }
     else
     {
-      //Simulate() parallelism is via TBB
+      //Simulate() parallelism is via TBB, but comment out for now due to cost of
+      //task_scheduler_init
       //tbb::task_scheduler_init tbb_init(Config::numThreadsSimulation);
 
       ev.Simulate();


### PR DESCRIPTION
Converts MkBuilder::FindTracksBestHit() to TBB.

* Uses a nested parallel for loop similar to the one used for FindTracksCloneEngineTbb to increase parallelism opportunities (OMP version only parallelized the outer loop).
* Pull out loading the EventOfCandidates with Tracks into a separate routine outside the timed section to make a fair comparison with the combinatoric builders, since they have loading the EventOfCombCandidates outside the timed section.  For the best hit builder, this is a *large* serial section.
* Add a "pragma ivdep" to the SMatrix symmetric matrix assignment operator so that it vectorizes.  This doesn't affect the final benchmark results, as this mainly contributes to loading the EventOfCandidates, which is now excluded from the timed section.
* Change the indentation of FindTracksCloneEngineTbb to a slightly more compact style that I now prefer for tbb::parallel_for (no substantive change)

Benchmarks are in phiphi:/home/dsr/mictest-mt/2016-05-11-tbbbh.  These are not entirely clean as there were some competing tasks (mainly the vtune GUI on phiphi but also some competing tasks on mic0), but are good enough for the purpose.  Results show significant improvement in scaling.
