### PR TITLE
switching input method for the fit test from CopyIn to SlurpIn…

### DIFF
--- a/Matriplex/Matriplex.h
+++ b/Matriplex/Matriplex.h
@@ -125,6 +125,8 @@ public:
    {
       for (int i = 0; i < kSize; ++i)
       {
+        // Next loop vectorizes with "#pragma ivdep", but it runs slower
+	// #pragma ivdep
         for (int j = 0; j < N; ++j)
         {
            fArray[i*N + j] = * (const T*) (arr + i*sizeof(T) + vi[j]);

--- a/Matriplex/MatriplexSym.h
+++ b/Matriplex/MatriplexSym.h
@@ -178,6 +178,7 @@ public:
    {
       // Does *this = a - b;
 
+#pragma ivdep
       for (idx_t i = 0; i < kTotSize; ++i)
       {
          fArray[i] = a.fArray[i] - b.fArray[i];

--- a/mkFit/MkFitter.h
+++ b/mkFit/MkFitter.h
@@ -62,6 +62,7 @@ public:
   //int getXHitEnd  (int arg0,int arg1,int arg2) { return XHitEnd  .At(arg0, arg1, arg2); }
 
   void InputTracksAndHits(std::vector<Track>& tracks, std::vector<HitVec>& layerHits, int beg, int end);
+  void SlurpInTracksAndHits(std::vector<Track>&  tracks, std::vector<HitVec>& layerHits, int beg, int end);
   void InputTracksAndHitIdx(std::vector<Track>& tracks,
                             int beg, int end, bool inputProp);
   void InputTracksAndHitIdx(std::vector<std::vector<Track> >& tracks, std::vector<std::pair<int,int> >& idxs,

--- a/mkFit/fittestMPlex.cc
+++ b/mkFit/fittestMPlex.cc
@@ -138,7 +138,9 @@ double runFittingTestPlex(Event& ev, std::vector<Track>& rectracks)
 
       MkFitter *mkfp = mkfp_arr[omp_get_thread_num()];
 
-      mkfp->InputTracksAndHits(simtracks, ev.layerHits_, itrack, end);
+      //mkfp->InputTracksAndHits(simtracks, ev.layerHits_, itrack, end);
+      mkfp->SlurpInTracksAndHits(simtracks, ev.layerHits_, itrack, end);
+
       if (Config::cf_fitting) mkfp->ConformalFitTracks(true, itrack, end);
       mkfp->FitTracks();
 


### PR DESCRIPTION
...MatriplexSym::Subtract now vectorizes
1. Code performs best when MPLEX_USE_INTRINSICS is defined
2. Testing has not been performed with USE_CUDA, it may well be broken in SlurpInTracksAndHits