### PR TITLE
Small fixups in SMatrix: validation, command line arguments

### DIFF
--- a/Hit.h
+++ b/Hit.h
@@ -143,6 +143,27 @@ inline float getEtaErr2(float x, float y, float z, float exx, float eyy, float e
   return detadx*detadx*exx + detady*detady*eyy + detadz*detadz*ezz + 2*detadx*detady*exy + 2*detadx*detadz*exz + 2*detady*detadz*eyz;
 }
 
+inline float getPxPxErr2(float ipt, float phi, float vipt, float vphi){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cosP  = std::cos(phi);   
+  const float sinP  = std::sin(phi);
+  return iipt2*(iipt2*cosP*cosP*vipt + sinP*sinP*vphi);
+}
+
+inline float getPyPyErr2(float ipt, float phi, float vipt, float vphi){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cosP  = std::cos(phi);   
+  const float sinP  = std::sin(phi);
+  return iipt2*(iipt2*sinP*sinP*vipt + cosP*cosP*vphi);
+}
+
+inline float getPzPzErr2(float ipt, float theta, float vipt, float vtheta){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cotT  = 1.0f/std::tan(theta);   
+  const float cscT  = 1.0f/std::sin(theta);
+  return iipt2*(iipt2*cotT*cotT*vipt + cscT*cscT*cscT*cscT*vtheta);
+}
+
 struct MCHitInfo
 {
   MCHitInfo() {}

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -886,16 +886,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
   px_cf_debug_    = cfSeedTS.px();
   py_cf_debug_    = cfSeedTS.py();
   pz_cf_debug_    = cfSeedTS.pz();
-#ifdef POLCOORD
-  SMatrixSym66 cfSeed_cartErrs = cfSeedTS.cartesianErrors();
-  epxpx_cf_debug_ = cfSeed_cartErrs(3,3);
-  epypy_cf_debug_ = cfSeed_cartErrs(4,4);
-  epzpz_cf_debug_ = cfSeed_cartErrs(5,5);
-#else
   epxpx_cf_debug_ = cfSeedTS.epxpx();
   epypy_cf_debug_ = cfSeedTS.epypy();
   epzpz_cf_debug_ = cfSeedTS.epzpz();
-#endif
 
   pt_cf_debug_   = cfSeedTS.pT();
   phi_cf_debug_  = cfSeedTS.momPhi();
@@ -925,16 +918,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
     px_prop_debug_[layer]    = propTS.px();
     py_prop_debug_[layer]    = propTS.py();
     pz_prop_debug_[layer]    = propTS.pz();
-#ifdef POLCOORD
-    SMatrixSym66 prop_cartErrs = propTS.cartesianErrors();
-    epxpx_prop_debug_[layer] = prop_cartErrs(3,3);
-    epypy_prop_debug_[layer] = prop_cartErrs(4,4);
-    epzpz_prop_debug_[layer] = prop_cartErrs(5,5);
-#else
     epxpx_prop_debug_[layer] = propTS.epxpx();
     epypy_prop_debug_[layer] = propTS.epypy();
     epzpz_prop_debug_[layer] = propTS.epzpz();
-#endif
 
     pt_prop_debug_[layer]   = propTS.pT();
     phi_prop_debug_[layer]  = propTS.momPhi();
@@ -972,16 +958,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
     px_up_debug_[layer]    = upTS.px();
     py_up_debug_[layer]    = upTS.py();
     pz_up_debug_[layer]    = upTS.pz();
-#ifdef POLCOORD
-    SMatrixSym66 up_cartErrs = upTS.cartesianErrors();
-    epxpx_up_debug_[layer] = up_cartErrs(3,3);
-    epypy_up_debug_[layer] = up_cartErrs(4,4);
-    epzpz_up_debug_[layer] = up_cartErrs(5,5);
-#else
     epxpx_up_debug_[layer] = upTS.epxpx();
     epypy_up_debug_[layer] = upTS.epypy();
     epzpz_up_debug_[layer] = upTS.epzpz();
-#endif
 
     pt_up_debug_[layer]   = upTS.pT();
     phi_up_debug_[layer]  = upTS.momPhi();
@@ -1837,17 +1816,9 @@ void TTreeValidation::fillConformalTree(const Event& ev){
       px_seed_cf_ = cfSeedTS.px();
       py_seed_cf_ = cfSeedTS.py();
       pz_seed_cf_ = cfSeedTS.pz();
-
-#ifdef POLCOORD
-      SMatrixSym66 cfSeed_cartErrs = cfSeedTS.cartesianErrors();
-      epx_seed_cf_ = cfSeed_cartErrs(3,3);
-      epy_seed_cf_ = cfSeed_cartErrs(4,4);
-      epz_seed_cf_ = cfSeed_cartErrs(5,5);
-#else
       epx_seed_cf_ = cfSeedTS.epxpx();
       epy_seed_cf_ = cfSeedTS.epypy();
       epz_seed_cf_ = cfSeedTS.epzpz();
-#endif
 
       pt_seed_cf_    = cfSeedTS.pT();
       invpt_seed_cf_ = cfSeedTS.invpT();
@@ -1940,17 +1911,9 @@ void TTreeValidation::fillConformalTree(const Event& ev){
       px_fit_cf_ = cfFitTS.px();
       py_fit_cf_ = cfFitTS.py();
       pz_fit_cf_ = cfFitTS.pz();
-
-#ifdef POLCOORD
-      SMatrixSym66 cfFit_cartErrs = cfFitTS.cartesianErrors();
-      epx_fit_cf_ = cfFit_cartErrs(3,3);
-      epy_fit_cf_ = cfFit_cartErrs(4,4);
-      epz_fit_cf_ = cfFit_cartErrs(5,5);
-#else
       epx_fit_cf_ = cfFitTS.epxpx();
       epy_fit_cf_ = cfFitTS.epypy();
       epz_fit_cf_ = cfFitTS.epzpz();
-#endif
 
       pt_fit_cf_    = cfFitTS.pT();
       invpt_fit_cf_ = cfFitTS.invpT();

--- a/Track.h
+++ b/Track.h
@@ -58,8 +58,12 @@ public:
   float einvpT()  const {return std::sqrt(errors.At(3,3));}
   float emomPhi() const {return std::sqrt(errors.At(4,4));}
   float etheta()  const {return std::sqrt(errors.At(5,5));}
-  float epT()     const {return std::sqrt(errors.At(3,3))/(parameters.At(3)*parameters.At(3));}//fixme: double check
-  float emomEta() const {return std::sqrt(errors.At(5,5))/std::sin(parameters.At(5));}//fixme: double check
+  float epT()     const {return std::sqrt(errors.At(3,3))/(parameters.At(3)*parameters.At(3));}
+  float emomEta() const {return std::sqrt(errors.At(5,5))/std::sin(parameters.At(5));}
+  float epxpx()   const {return std::sqrt(getPxPxErr2(invpT(),momPhi(),errors.At(3,3),errors.At(4,4)));}
+  float epypy()   const {return std::sqrt(getPyPyErr2(invpT(),momPhi(),errors.At(3,3),errors.At(4,4)));}
+  float epzpz()   const {return std::sqrt(getPyPyErr2(invpT(),theta(),errors.At(3,3),errors.At(5,5)));}
+  // special note: KPM --> do not need cross terms in jacobian anymore, don't store them in validation anyways
 
 #else
   float px()     const {return parameters.At(3);}

--- a/main.cc
+++ b/main.cc
@@ -135,16 +135,30 @@ int main(int argc, const char* argv[])
       printf(
         "Usage: %s [options]\n"
         "Options:\n"
+	"  --num-events    <num>    number of events to run over (def: %d)\n"
+        "  --num-tracks    <num>    number of tracks to generate for each event (def: %d)\n"
 	"  --num-thr       <num>    number of threads used for TBB  (def: %d)\n"
 	"  --super-debug            bool to enable super debug mode (def: %s)\n"
 	"  --cf-seeding             bool to enable CF in MC seeding (def: %s)\n"
-        ,
+	,
         argv[0],
+	Config::nEvents,
+	Config::nTracks,
         nThread, 
 	(Config::super_debug ? "true" : "false"),
 	(Config::cf_seeding  ? "true" : "false")
       );
       exit(0);
+    }
+    else if (*i == "--num-events")
+    {
+      next_arg_or_die(mArgs, i);
+      Config::nEvents = atoi(i->c_str());
+    }
+    else if (*i == "--num-tracks")
+    {
+      next_arg_or_die(mArgs, i);
+      Config::nTracks = atoi(i->c_str());
     }
     else if (*i == "--num-thr")
     {


### PR DESCRIPTION
- Restore momentum errors in validation (add some accessors to TrackState and some inline calculations to Hit.h)
- Add ntracks, nevents as command line options in SMatrix 

The full track validation is here:  https://kmcdermo.web.cern.ch/kmcdermo/pr52_validation/

A few things to note:
1. To get SMatrix to run without crashing, need to disable CCS coords (ifdef in Config.h), as SMatrix propagation uses old global cartesian coordinates.  Simulation still uses this coordinate system as well (and also uses the SMatrix methods for propagation).
2. This was over MC seeds, 5000tks/evt * 10 evts.    
3. Phi/eta pulls look okay... although pT pull looks a bit more biased than before, and less gaussian.  Something to keep an eye on.
4. I will submit another PR with the CCS propagation ported to SMatrix after porting seeding to mkFit.

As this PR does not touch anything in mkFit, it can be merged automatically without benchmarking.
