### PR TITLE
Fixups of validation, fittest; new seeding routine to be ported to mkFit

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -91,8 +91,8 @@ namespace Config
   // Config for seeding
   constexpr int   nlayers_per_seed = 3;
   constexpr float chi2seedcut  = 9.0;
-  constexpr float lay12angdiff = 0.0634888; // analytically derived... depends on geometry of detector --> from mathematica ... d0 set to one sigma of getHypot(bsX,bsY)
-  constexpr float lay13angdiff = 0.11537;
+  constexpr float lay01angdiff = 0.0634888; // analytically derived... depends on geometry of detector --> from mathematica ... d0 set to one sigma of getHypot(bsX,bsY)
+  constexpr float lay02angdiff = 0.11537;
   constexpr float dEtaSeedTrip = 0.6; // for almost max efficiency --> empirically derived... depends on geometry of detector
   constexpr float dPhiSeedTrip = 0.0458712; // numerically+semianalytically derived... depends on geometry of detector
   constexpr float seed_z0cut   = beamspotZ * 3.0; // 3cm
@@ -137,8 +137,8 @@ namespace Config
   constexpr float thetaerr049 = 0.0033; // 0.0031; 
   // parameters for layers 0,1,2 // --> ENDTOEND with "real seeding", fit is outward by definition, with poly geo
   constexpr float ptinverr012 = 0.12007; // 0.1789;  -->old values from only MC seeds
-  constexpr float phierr012   = 0.00646; // 0.0071 
-  constexpr float thetaerr012 = 0.01366; // 0.0130; 
+  constexpr float phierr012   = 1.0; // found empirically 0.00646; // 0.0071 
+  constexpr float thetaerr012 = 0.2; // also found empirically 0.01366; // 0.0130; 
 
   // config on fitting
   extern bool cf_fitting;

--- a/Event.cc
+++ b/Event.cc
@@ -227,7 +227,8 @@ void Event::Segment()
   void Event::Seed()
 {
 #ifdef ENDTOEND
-  buildSeedsByRoadTriplets(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
+  buildSeedsByRoadSearch(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
+  //  buildSeedsByRoadTriplets(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
   //buildSeedsByRZFirstRPhiSecond(seedTracks_,seedTracksExtra_,layerHits_,segmentMap_,*this);
 #else
   buildSeedsByMC(simTracks_,seedTracks_,seedTracksExtra_,*this);

--- a/Hit.h
+++ b/Hit.h
@@ -143,6 +143,27 @@ inline float getEtaErr2(float x, float y, float z, float exx, float eyy, float e
   return detadx*detadx*exx + detady*detady*eyy + detadz*detadz*ezz + 2*detadx*detady*exy + 2*detadx*detadz*exz + 2*detady*detadz*eyz;
 }
 
+inline float getPxPxErr2(float ipt, float phi, float vipt, float vphi){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cosP  = std::cos(phi);   
+  const float sinP  = std::sin(phi);
+  return iipt2*(iipt2*cosP*cosP*vipt + sinP*sinP*vphi);
+}
+
+inline float getPyPyErr2(float ipt, float phi, float vipt, float vphi){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cosP  = std::cos(phi);   
+  const float sinP  = std::sin(phi);
+  return iipt2*(iipt2*sinP*sinP*vipt + cosP*cosP*vphi);
+}
+
+inline float getPzPzErr2(float ipt, float theta, float vipt, float vtheta){ // ipt = 1/pT, v = variance
+  const float iipt2 = 1.0f/(ipt*ipt); //iipt = 1/(1/pT) = pT
+  const float cotT  = 1.0f/std::tan(theta);   
+  const float cscT  = 1.0f/std::sin(theta);
+  return iipt2*(iipt2*cotT*cotT*vipt + cscT*cscT*cscT*cscT*vtheta);
+}
+
 struct MCHitInfo
 {
   MCHitInfo() {}

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -886,16 +886,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
   px_cf_debug_    = cfSeedTS.px();
   py_cf_debug_    = cfSeedTS.py();
   pz_cf_debug_    = cfSeedTS.pz();
-#ifdef CCSCOORD
-  SMatrixSym66 cfSeed_cartErrs = cfSeedTS.cartesianErrors();
-  epxpx_cf_debug_ = cfSeed_cartErrs(3,3);
-  epypy_cf_debug_ = cfSeed_cartErrs(4,4);
-  epzpz_cf_debug_ = cfSeed_cartErrs(5,5);
-#else
   epxpx_cf_debug_ = cfSeedTS.epxpx();
   epypy_cf_debug_ = cfSeedTS.epypy();
   epzpz_cf_debug_ = cfSeedTS.epzpz();
-#endif
 
   pt_cf_debug_   = cfSeedTS.pT();
   phi_cf_debug_  = cfSeedTS.momPhi();
@@ -925,16 +918,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
     px_prop_debug_[layer]    = propTS.px();
     py_prop_debug_[layer]    = propTS.py();
     pz_prop_debug_[layer]    = propTS.pz();
-#ifdef CCSCOORD
-    SMatrixSym66 prop_cartErrs = propTS.cartesianErrors();
-    epxpx_prop_debug_[layer] = prop_cartErrs(3,3);
-    epypy_prop_debug_[layer] = prop_cartErrs(4,4);
-    epzpz_prop_debug_[layer] = prop_cartErrs(5,5);
-#else
     epxpx_prop_debug_[layer] = propTS.epxpx();
     epypy_prop_debug_[layer] = propTS.epypy();
     epzpz_prop_debug_[layer] = propTS.epzpz();
-#endif
 
     pt_prop_debug_[layer]   = propTS.pT();
     phi_prop_debug_[layer]  = propTS.momPhi();
@@ -972,16 +958,9 @@ void TTreeValidation::fillDebugTree(const Event& ev){
     px_up_debug_[layer]    = upTS.px();
     py_up_debug_[layer]    = upTS.py();
     pz_up_debug_[layer]    = upTS.pz();
-#ifdef CCSCOORD
-    SMatrixSym66 up_cartErrs = upTS.cartesianErrors();
-    epxpx_up_debug_[layer] = up_cartErrs(3,3);
-    epypy_up_debug_[layer] = up_cartErrs(4,4);
-    epzpz_up_debug_[layer] = up_cartErrs(5,5);
-#else
     epxpx_up_debug_[layer] = upTS.epxpx();
     epypy_up_debug_[layer] = upTS.epypy();
     epzpz_up_debug_[layer] = upTS.epzpz();
-#endif
 
     pt_up_debug_[layer]   = upTS.pT();
     phi_up_debug_[layer]  = upTS.momPhi();
@@ -1837,17 +1816,9 @@ void TTreeValidation::fillConformalTree(const Event& ev){
       px_seed_cf_ = cfSeedTS.px();
       py_seed_cf_ = cfSeedTS.py();
       pz_seed_cf_ = cfSeedTS.pz();
-
-#ifdef CCSCOORD
-      SMatrixSym66 cfSeed_cartErrs = cfSeedTS.cartesianErrors();
-      epx_seed_cf_ = cfSeed_cartErrs(3,3);
-      epy_seed_cf_ = cfSeed_cartErrs(4,4);
-      epz_seed_cf_ = cfSeed_cartErrs(5,5);
-#else
       epx_seed_cf_ = cfSeedTS.epxpx();
       epy_seed_cf_ = cfSeedTS.epypy();
       epz_seed_cf_ = cfSeedTS.epzpz();
-#endif
 
       pt_seed_cf_    = cfSeedTS.pT();
       invpt_seed_cf_ = cfSeedTS.invpT();
@@ -1940,17 +1911,9 @@ void TTreeValidation::fillConformalTree(const Event& ev){
       px_fit_cf_ = cfFitTS.px();
       py_fit_cf_ = cfFitTS.py();
       pz_fit_cf_ = cfFitTS.pz();
-
-#ifdef CCSCOORD
-      SMatrixSym66 cfFit_cartErrs = cfFitTS.cartesianErrors();
-      epx_fit_cf_ = cfFit_cartErrs(3,3);
-      epy_fit_cf_ = cfFit_cartErrs(4,4);
-      epz_fit_cf_ = cfFit_cartErrs(5,5);
-#else
       epx_fit_cf_ = cfFitTS.epxpx();
       epy_fit_cf_ = cfFitTS.epypy();
       epz_fit_cf_ = cfFitTS.epzpz();
-#endif
 
       pt_fit_cf_    = cfFitTS.pT();
       invpt_fit_cf_ = cfFitTS.invpT();

--- a/Track.h
+++ b/Track.h
@@ -58,8 +58,12 @@ public:
   float einvpT()  const {return std::sqrt(errors.At(3,3));}
   float emomPhi() const {return std::sqrt(errors.At(4,4));}
   float etheta()  const {return std::sqrt(errors.At(5,5));}
-  float epT()     const {return std::sqrt(errors.At(3,3))/(parameters.At(3)*parameters.At(3));}//fixme: double check
-  float emomEta() const {return std::sqrt(errors.At(5,5))/std::sin(parameters.At(5));}//fixme: double check
+  float epT()     const {return std::sqrt(errors.At(3,3))/(parameters.At(3)*parameters.At(3));}
+  float emomEta() const {return std::sqrt(errors.At(5,5))/std::sin(parameters.At(5));}
+  float epxpx()   const {return std::sqrt(getPxPxErr2(invpT(),momPhi(),errors.At(3,3),errors.At(4,4)));}
+  float epypy()   const {return std::sqrt(getPyPyErr2(invpT(),momPhi(),errors.At(3,3),errors.At(4,4)));}
+  float epzpz()   const {return std::sqrt(getPyPyErr2(invpT(),theta(),errors.At(3,3),errors.At(5,5)));}
+  // special note: KPM --> do not need cross terms in jacobian anymore, don't store them in validation anyways
 
 #else
   float px()     const {return parameters.At(3);}

--- a/fittest.cc
+++ b/fittest.cc
@@ -32,18 +32,13 @@ void fitTrack(const Track & trk, const TrackExtra& trkextra, int itrack, Event& 
 #define CONFORMAL
 #ifdef CONFORMAL
   const bool fiterrs  = true;
-  //fit is problematic in case of very short lever arm
-  // hits from track foundLayers(): 0, size()/2, size()-1.
-  // i.e. outward: front(), size()/2, back()  of foundLayers()
-  // i.e. inward:  back(),  size()/2, front() of foundLayers()
-  // for 10 hits outward this 0,  5, 10; for 9 hits this is 0, 4, 9; for 3 hits this is 0, 1, 2.
-  // for 10 hits inward  this 10, 4, 0;  for 9 hits this is 9, 4, 0; for 3 hits this is 2, 1, 0.
 
+  // hits from track foundLayers(): 0, size()/2, size()-1.
+  auto middlelayer = trkLayers[trkLayers.size()/2];
+  const Hit& hit2 = evt_lay_hits[middlelayer][trk.getHitIdx(middlelayer)];
 #ifdef INWARDFIT
-  const Hit& hit2 = evt_lay_hits[trkLayers.size()/2][trk.getHitIdx(trkLayers.size()/2)];
   const Hit& hit3 = evt_lay_hits[trkLayers.front()][trk.getHitIdx(trkLayers.front())];
 #else
-  const Hit& hit2 = evt_lay_hits[trkLayers.size()/2][trk.getHitIdx(trkLayers.size()/2)];
   const Hit& hit3 = evt_lay_hits[trkLayers.back()][trk.getHitIdx(trkLayers.back())];
 #endif
   conformalFit(hit1,hit2,hit3,trk.charge(),cfitStateHit0,fiterrs); // last bool denotes use cf derived errors for fitting
@@ -56,6 +51,7 @@ void fitTrack(const Track & trk, const TrackExtra& trkextra, int itrack, Event& 
 
 #if defined(ENDTOEND) || defined(CONFORMAL)
   updatedState.errors*=10;//not needed when fitting straight from simulation
+  dcall(print("conformalState", updatedState));
 #endif //ENDTOEND
 
   TSLayerPairVec updatedStates; // need this for position pulls --> can ifdef out for performance tests? --> assume one hit per layer

--- a/main.cc
+++ b/main.cc
@@ -135,16 +135,30 @@ int main(int argc, const char* argv[])
       printf(
         "Usage: %s [options]\n"
         "Options:\n"
+	"  --num-events    <num>    number of events to run over (def: %d)\n"
+        "  --num-tracks    <num>    number of tracks to generate for each event (def: %d)\n"
 	"  --num-thr       <num>    number of threads used for TBB  (def: %d)\n"
 	"  --super-debug            bool to enable super debug mode (def: %s)\n"
 	"  --cf-seeding             bool to enable CF in MC seeding (def: %s)\n"
-        ,
+	,
         argv[0],
+	Config::nEvents,
+	Config::nTracks,
         nThread, 
 	(Config::super_debug ? "true" : "false"),
 	(Config::cf_seeding  ? "true" : "false")
       );
       exit(0);
+    }
+    else if (*i == "--num-events")
+    {
+      next_arg_or_die(mArgs, i);
+      Config::nEvents = atoi(i->c_str());
+    }
+    else if (*i == "--num-tracks")
+    {
+      next_arg_or_die(mArgs, i);
+      Config::nTracks = atoi(i->c_str());
     }
     else if (*i == "--num-thr")
     {

--- a/seedtest.h
+++ b/seedtest.h
@@ -8,14 +8,16 @@
 
 void buildSeedsByMC(const TrackVec&, TrackVec&, TrackExtraVec&, Event&);
 void buildSeedsByRZFirstRPhiSecond(TrackVec&, TrackExtraVec&, const std::vector<HitVec>&, const BinInfoMap&, Event&);
-void filterHitTripletsByCircleParams(const std::vector<HitVec>&, const TripletIdxVec&, TripletIdxVec&);
 void buildSeedsByRoadTriplets(TrackVec&, TrackExtraVec&, const std::vector<HitVec>&, const BinInfoMap&, Event&);
+void buildSeedsByRoadSearch(TrackVec&, TrackExtraVec&, const std::vector<HitVec>&, const BinInfoMap&, Event&);
 void buildHitPairs(const std::vector<HitVec>&, const BinInfoLayerMap&, PairIdxVec&);
 void buildHitTripletsCurve(const std::vector<HitVec>&, const BinInfoLayerMap&, const PairIdxVec&, TripletIdxVec&);
 void buildHitTripletsApproxWindow(const std::vector<HitVec>&, const BinInfoLayerMap&, const PairIdxVec&, TripletIdxVec&);
 void intersectThirdLayer(const float, const float, const float, const float, float&, float&);
+void filterHitTripletsByCircleParams(const std::vector<HitVec>&, const TripletIdxVec&, TripletIdxVec&);
 void filterHitTripletsBySecondLayerZResidual(const std::vector<HitVec>&, const TripletIdxVec&, TripletIdxVec&);
 void filterHitTripletsByRZChi2(const std::vector<HitVec>&, const TripletIdxVec&, TripletIdxVec&);
 void buildSeedsFromTriplets(const std::vector<HitVec>&, const TripletIdxVec&, TrackVec&, TrackExtraVec&, Event&);
+void fitSeeds(const std::vector<HitVec>&, TrackVec&, Event&);
 
 #endif


### PR DESCRIPTION
Hi all,

This is a reopening of the PR that I closed from Friday.  I merged cleanly the changes on the head of devel, and I added some new routines and fixes.

The fittest fix was particularly nasty.  When we actually use the CF in mkFit we will have to watch out for this.  We will really need to use the foundLayers() routine in Track.h to correctly get the layers to process.  Otherwise the CF throws garbage nans and the like.  

This was in fact the bug I was chasing down over the weekend. After running the validation, the number of tracks processed in the validation for fitting vs building was different... although they should be the same (as we have no cuts between fittracks and builttracks).  To make matters worse, the different numbers were different based on the seeding routine used (i.e. the road search routines either unrolled or implemented as a set of small functions -- which should produced identical results!).  Ultimately, it was the CF crapping out on the fitting because it was trying to access Hit -1, and was still able to create a reference to an uninitialized hit with pars = 0, errs = 0... so it never crashed but produced garbage.

Okay, this is ready to be merged.